### PR TITLE
perf: fix type instabilities and allocation hotspots

### DIFF
--- a/src/boundary.jl
+++ b/src/boundary.jl
@@ -31,7 +31,10 @@ end
 
 function PointBoundary(points)
     normals = compute_normals(points)
-    areas = zeros(length(points)) * Unitful.m^2
+    C = crs(first(points))
+    T = CoordRefSystems.mactype(C)
+    L = lentype(C)
+    areas = zeros(typeof(zero(T) * oneunit(L)^2), length(points))
     return PointBoundary(points, normals, areas)
 end
 

--- a/src/discretization/spacings.jl
+++ b/src/discretization/spacings.jl
@@ -7,6 +7,16 @@ abstract type VariableSpacing <: AbstractSpacing end
 distance(p1::Point{𝔼{N}}, p2::Point{𝔼{N}}) where {N} = evaluate(Euclidean(), p1, p2)
 distance(p1::Vec{N}, p2::Vec{N}) where {N} = evaluate(Euclidean(), p1, p2)
 
+# Find minimum distance from point p to any point in boundary without allocating
+function _min_distance(p, boundary)
+    dmin = distance(p, first(boundary))
+    @inbounds for i in 2:length(boundary)
+        d = distance(p, boundary[i])
+        dmin = ifelse(d < dmin, d, dmin)
+    end
+    return dmin
+end
+
 """
     ConstantSpacing{L<:Unitful.Length} <: AbstractSpacing
 
@@ -26,8 +36,8 @@ Node spacing based on a log-like function of the distance to nearest boundary ``
     the growth rate as ``a = 1 - (g - 1)`` where ``g`` is the conventional growth rate
     parameter.
 """
-struct LogLike{B, G} <: VariableSpacing
-    boundary::Any
+struct LogLike{B, G, P} <: VariableSpacing
+    boundary::P
     base_size::B
     growth_rate::G
 end
@@ -38,7 +48,7 @@ function LogLike(cloud::PointCloud, base_size, growth_rate)
 end
 
 function (s::LogLike)(p::Union{Point, Vec})
-    x, _ = findmin_turbo(distance.(p, s.boundary))
+    x = _min_distance(p, s.boundary)
     inv_growth = 1 - (s.growth_rate - 1)
     a = s.base_size * inv_growth  # characteristic length scale with proper units
     return s.base_size * x / (a + x)
@@ -63,8 +73,8 @@ spacing = BoundaryLayerSpacing(boundary, at_wall=0.5m, bulk=10m, layer_thickness
 Internally uses sigmoid: `h(d) = at_wall + (bulk - at_wall) * σ(d)`
 where `σ(d) = 1 / (1 + exp(-(d - δ/2) / (δ/6)))` and δ = layer_thickness.
 """
-struct BoundaryLayerSpacing{B, L} <: VariableSpacing
-    boundary::Any
+struct BoundaryLayerSpacing{B, L, P} <: VariableSpacing
+    boundary::P
     at_wall::B
     bulk::B
     layer_thickness::L
@@ -80,7 +90,7 @@ function BoundaryLayerSpacing(boundary_points; at_wall, bulk, layer_thickness)
     h_wall = convert(B, at_wall)
     h_bulk = convert(B, bulk)
 
-    return BoundaryLayerSpacing{B, typeof(layer_thickness)}(
+    return BoundaryLayerSpacing{B, typeof(layer_thickness), typeof(boundary_points)}(
         boundary_points,
         h_wall,
         h_bulk,
@@ -90,7 +100,7 @@ end
 
 function (s::BoundaryLayerSpacing)(p::Union{Point, Vec})
     # Distance to nearest boundary point
-    x, _ = findmin_turbo(distance.(p, s.boundary))
+    x = _min_distance(p, s.boundary)
     d = Float64(ustrip(x))
 
     # Sigmoid transition: center at δ/2, width ≈ δ/6 (smooth S-curve over boundary layer)

--- a/src/io.jl
+++ b/src/io.jl
@@ -8,9 +8,10 @@ function import_surface(filepath::String)
     geo = GeoIO.load(filepath)
     mesh = geo.geometry
     points = map(centroid, elements(mesh))
-    n = try
+    n = if hasproperty(geo, :normal)
         geo.normal
-    catch
+    else
+        @info "No normals found in file, computing via PCA"
         compute_normals(points)
     end
     normals = map(x -> ustrip.(x / norm(x)), n)

--- a/src/isinside.jl
+++ b/src/isinside.jl
@@ -41,6 +41,7 @@ function isinside(
 end
 
 function _greens(testpoint::Point{𝔼{N}}, surf::PointSurface{𝔼{N}, C}) where {N, C <: CRS}
+    T = CoordRefSystems.mactype(C)
     _greens_kernel = let testpoint = testpoint
         geom -> begin
             (; point, normal, area) = geom
@@ -48,6 +49,6 @@ function _greens(testpoint::Point{𝔼{N}}, surf::PointSurface{𝔼{N}, C}) wher
             return area * dist ⋅ normal / norm(dist)^3
         end
     end
-    g = tmapreduce(_greens_kernel, +, surf; init = 0.0)
+    g = tmapreduce(_greens_kernel, +, surf; init = zero(T))
     return g # true ∇G⋅n eval should be divided by -4π here
 end

--- a/src/normals.jl
+++ b/src/normals.jl
@@ -95,20 +95,23 @@ function orient_normals!(
         normals[start] = -normals[start]
     end
 
-    # Depth-first traversal of minimum spanning tree
+    # Iterative DFS traversal of minimum spanning tree (avoids stack overflow on large clouds)
     parents = dfs_parents(g_mst, start)
     visited = falses(length(parents))
-    function visit(ivertex)
-        visited[ivertex] = true
+    stack = Int[start]
+    visited[start] = true
+    while !isempty(stack)
+        ivertex = pop!(stack)
         if normals[ivertex] ⋅ normals[parents[ivertex]] < 0
             normals[ivertex] = -normals[ivertex]
         end
         for nb in Graphs.neighbors(g_mst, ivertex)
-            !visited[nb] && visit(nb)
+            if !visited[nb]
+                visited[nb] = true
+                push!(stack, nb)
+            end
         end
-        return
     end
-    visit(start)
 
     return nothing
 end

--- a/src/repel.jl
+++ b/src/repel.jl
@@ -10,22 +10,22 @@ function repel(
         cloud::PointCloud{𝔼{N}, C},
         spacing;
         β = 0.2,
-        α = minimum(spacing(to(cloud))) * 0.05,
+        α = minimum(spacing.(to(cloud))) * 0.05,
         k = 21,
-        max_iters = 1.0e3,
+        max_iters = 1000,
         tol = 1.0e-6,
     ) where {N, C <: CRS}
     # Miotti 2023
     α = ustrip(α)
-    p = collect(volume(cloud).points)
+    p = copy(volume(cloud).points)
     p_old = deepcopy(p)
     npoints = length(p)
     all_p = points(cloud)
     method = KNearestSearch(all_p, k)
 
-    all_spacings = spacing(all_p)
-    convergence = let s = all_spacings
-        (p, p_old) -> norm(p .- p_old, Inf) ./ s
+    vol_spacings = ustrip.(spacing.(p))
+    convergence = let s = vol_spacings
+        (p, p_old) -> norm(ustrip.(norm.(p .- p_old)) ./ s, Inf)
     end
 
     conv = Float64[]
@@ -45,14 +45,14 @@ function repel(
 
             repel_force = sum(zip(neighborhood, rij)) do z
                 xj, r = z
-                F(r / s) * (xi - xj) / r
+                @inbounds F(r / s) * (xi - xj) / r
             end
 
             return xi + Vec(s * α * repel_force)
         end
         push!(conv, convergence(p, p_old))
-        if all(x -> norm(x, Inf) < tol, conv[end])
-            println("Node repel finished in $i iterations. Convergence = ($conv[end])")
+        if conv[end] < tol
+            println("Node repel finished in $i iterations. Convergence = $(conv[end])")
             break
         end
         i = i + 1

--- a/src/surface.jl
+++ b/src/surface.jl
@@ -20,7 +20,7 @@ Meshes.crs(::Type{<:SurfaceElement{M, C}}) where {M, C} = C
 Meshes.crs(se::SurfaceElement) = crs(se.point)
 
 """
-    struct PointSurface{M,C,S,T} <: AbstractSurface{M,C}
+    struct PointSurface{M,C,S,T,G} <: AbstractSurface{M,C}
 
 This is a typical representation of a surface via points.
 
@@ -29,20 +29,21 @@ This is a typical representation of a surface via points.
 - `C<:CRS` - coordinate reference system
 - `S` - shadow type
 - `T<:AbstractTopology` - topology type for surface-local connectivity
+- `G<:StructVector` - storage type for surface elements
 """
-struct PointSurface{M <: Manifold, C <: CRS, S, T <: AbstractTopology} <: AbstractSurface{M, C}
-    geoms::StructVector{SurfaceElement}
+struct PointSurface{M <: Manifold, C <: CRS, S, T <: AbstractTopology, G <: StructVector} <: AbstractSurface{M, C}
+    geoms::G
     shadow::S
     topology::T
     function PointSurface(
-            geoms::StructVector{SurfaceElement},
+            geoms::G,
             shadow::S = nothing,
             topology::T = NoTopology(),
-        ) where {S, T <: AbstractTopology}
+        ) where {G <: StructVector, S, T <: AbstractTopology}
         p = first(geoms.point)
         M = manifold(p)
         C = crs(p)
-        return new{M, C, S, T}(geoms, shadow, topology)
+        return new{M, C, S, T, G}(geoms, shadow, topology)
     end
 end
 

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -1,7 +1,7 @@
 function findmin_turbo(x)
     indmin = 0
     minval = typemax(eltype(x))
-    for (i, y) in enumerate(x)
+    @inbounds for (i, y) in enumerate(x)
         newmin = y < minval
         minval = newmin ? y : minval
         indmin = newmin ? i : indmin
@@ -12,7 +12,7 @@ end
 function ranges_from_permutation(permutations::AbstractVector)
     num_elems = length.(permutations)
     # use cumsum here
-    ends = map(i -> sum(num_elems[begin:i]), 1:length(num_elems))
+    ends = cumsum(num_elems)
     ranges = [(e - num_elems[i] + 1):e for (i, e) in enumerate(ends)]
     return ranges
 end


### PR DESCRIPTION
## Summary

Addresses #70 — fixes type instabilities, unnecessary allocations, and correctness issues across 8 source files with no public API changes.

- **Parameterize `boundary::Any`** in `LogLike` and `BoundaryLayerSpacing` to eliminate dynamic dispatch in hot-path spacing callables
- **Eliminate O(N) allocation per spacing call** by replacing `distance.(p, s.boundary)` broadcast + `findmin_turbo` with a fused `_min_distance` loop that tracks the minimum without allocating
- **Fully parameterize `StructVector`** in `PointSurface` so the compiler can infer column types at compile time
- **Fix hardcoded `init = 0.0`** in `_greens` `tmapreduce` — now derives zero from CRS mactype
- **Replace recursive DFS** in `orient_normals!` with iterative stack-based traversal to prevent stack overflow on large point clouds (100k+)
- **Fix `repel` convergence**: dimension mismatch (was using all-point spacings against volume-only displacements), `collect` → `copy`, `max_iters` Float → Int, proper scalar Inf-norm convergence metric
- **Add `@inbounds`** to `findmin_turbo` and repel force inner loop
- **Replace O(n²) `ranges_from_permutation`** with `cumsum`
- **Replace bare `try/catch`** in `import_surface` with `hasproperty` check
- **Derive area units from CRS** instead of hardcoding `m²` in `PointBoundary`