### PR TITLE
refactor(api): improve docs, validation, and consistency

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -192,11 +192,14 @@ split_surface!(boundary, 75°)
 ### Node Repulsion Optimization
 
 ```julia
-# Optimize point distribution (returns tuple)
-cloud, convergence = repel(cloud, spacing; β=0.2, max_iters=1000)
+# Optimize point distribution
+cloud = repel(cloud, spacing; β=0.2, max_iters=1000)
+
+# Collect convergence history via keyword
+conv = Float64[]
+cloud = repel(cloud, spacing; β=0.2, max_iters=1000, convergence=conv)
 
 # β controls repulsion strength
-# Returns (new_cloud, convergence_vector) tuple
 # New cloud has NoTopology since points moved
 ```
 
@@ -218,10 +221,10 @@ visualize(boundary; markersize=0.15)
 - `split_surface!` - Split boundary surfaces by normal angle threshold
 - `combine_surfaces!` - Merge multiple surfaces into one
 - `compute_normals` / `orient_normals!` - Normal vector handling
-- `repel` - Optimize point distribution via node repulsion (returns new cloud, convergence)
+- `repel` - Optimize point distribution via node repulsion (returns new cloud)
 - `isinside` - Test if point is inside domain
 - `import_surface` - Load from STL/mesh files (via GeoIO.jl)
-- `export_cloud` - Save to VTK format
+- `save` - Save to file (`:jld2` default, or `:vtk` format)
 - `visualize` - Makie-based visualization
 - `set_topology` - Build point connectivity and return new object
 - `rebuild_topology!` - Rebuild topology in place with same parameters

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,6 +39,7 @@ All types inherit from `Domain{M,C}` where `M<:Manifold` and `C<:CRS` (coordinat
 
 - **Composition over inheritance:** Types build on each other (surfaces → boundary → cloud)
 - **Immutability:** PointSurface is immutable; PointCloud is mutable for iterative construction
+- **Mutation convention:** Geometry creation/transformation is functional (returns new objects). Metadata reorganization and derived-quantity recomputation (`split_surface!`, `orient_normals!`, `rebuild_topology!`) mutates in-place, indicated by `!`.
 - **StructArrays:** Surface elements stored as StructArray for cache-friendly memory layout
 - **Heavy parallelization:** Uses OhMyThreads (tmap, tmapreduce) throughout
 - **Full unit support:** Unitful.jl integrated across all operations
@@ -71,7 +72,7 @@ Four algorithms available with **important 2D vs 3D considerations:**
 - **SlakKosec** (3D only, default) - `algorithms/slak_kosec.jl`
 - **VanDerSandeFornberg** (3D only) - `algorithms/vandersande_fornberg.jl`
 - **FornbergFlyer** (2D only) - `algorithms/fornberg_flyer.jl`
-- **Octree** (3D only) - `algorithms/octree.jl` — dual-octree spacing-driven adaptive fill
+- **Octree** (3D only) - `algorithms/octree.jl` — dual-octree spacing-driven adaptive fill (this is a discretization *algorithm*; not to be confused with `TriangleOctree`, a spatial *data structure*)
 
 Spacing types in `spacings.jl`: ConstantSpacing, LogLike, BoundaryLayerSpacing
 

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ spacing = ConstantSpacing(1u"mm")
 cloud = discretize(boundary, spacing; alg=VanDerSandeFornberg(), max_points=100_000)
 
 # Optimize point distribution
-cloud, convergence = repel(cloud, spacing; β=0.2, max_iters=1000)
+cloud = repel(cloud, spacing; β=0.2, max_iters=1000)
 
 # Add point connectivity
 cloud = set_topology(cloud, KNNTopology, 21)

--- a/docs/generate_images.jl
+++ b/docs/generate_images.jl
@@ -106,7 +106,7 @@ function generate_repel_comparison()
     spacing = WTP.ConstantSpacing((dx / 60) * m)
     cloud_before = WTP.discretize(boundary, spacing; alg = WTP.FornbergFlyer())
 
-    cloud_after, convergence = WTP.repel(cloud_before, spacing; max_iters = 500)
+    cloud_after = WTP.repel(cloud_before, spacing; max_iters = 500)
 
     fig = Figure(; size = (1400, 600))
 

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -23,7 +23,6 @@ Common accessor functions for point cloud types.
 
 ```@docs
 points
-point
 normal
 area
 topology
@@ -50,6 +49,7 @@ Volume point generation algorithms and spacing types.
 
 ```@docs
 discretize
+AbstractSpacing
 SlakKosec
 VanDerSandeFornberg
 FornbergFlyer

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -111,7 +111,6 @@ metrics
 
 ```@docs
 import_surface
-export_cloud
 save
 ```
 

--- a/docs/src/concepts.md
+++ b/docs/src/concepts.md
@@ -48,7 +48,12 @@ cloud3 = repel(cloud2, spacing)
 
 This design ensures compatibility with automatic differentiation frameworks and prevents stale state — if points move, the old topology object simply isn't used.
 
-**Exceptions:** `split_surface!` and `combine_surfaces!` mutate a `PointBoundary`'s internal surface dictionary. These are in-place operations by convention (indicated by the `!` suffix) because they only reorganize existing surfaces without changing any point data.
+**Exceptions — mutating operations (indicated by `!` suffix):**
+- `split_surface!` and `combine_surfaces!` mutate a `PointBoundary`'s internal surface dictionary. These reorganize existing surfaces without changing any point data.
+- `rebuild_topology!` recomputes connectivity data in place for mutable topology types (`KNNTopology`, `RadiusTopology`), avoiding reallocation when only the spatial index needs refreshing.
+- `orient_normals!` and `update_normals!` mutate normal vectors in place for efficiency, since normal arrays can be large and reorientation is a pure numerical update.
+
+The pattern is: **geometry creation and transformation** (new point data) uses functional style; **metadata reorganization and derived-quantity recomputation** (normals, topology, surface labels) mutates in-place.
 
 ## Topology
 

--- a/docs/src/concepts.md
+++ b/docs/src/concepts.md
@@ -43,7 +43,7 @@ Most types in WhatsThePoint are **immutable**. Operations return new objects rat
 cloud2 = set_topology(cloud, KNNTopology, 21)
 
 # repel returns a new cloud (with NoTopology, since points moved)
-cloud3, convergence = repel(cloud2, spacing)
+cloud3 = repel(cloud2, spacing)
 ```
 
 This design ensures compatibility with automatic differentiation frameworks and prevents stale state — if points move, the old topology object simply isn't used.

--- a/docs/src/guide.md
+++ b/docs/src/guide.md
@@ -123,16 +123,20 @@ For a complete runnable example, see
 Discretization gives approximate uniformity; repulsion refines it to minimize interpolation error in the meshless solver.
 
 ```julia
-cloud, convergence = repel(cloud, spacing; β=0.2, max_iters=1000)
+cloud = repel(cloud, spacing; β=0.2, max_iters=1000)
+
+# Collect convergence history via keyword
+conv = Float64[]
+cloud = repel(cloud, spacing; β=0.2, max_iters=1000, convergence=conv)
 ```
 
-`repel` returns a tuple of `(new_cloud, convergence_vector)`. The new cloud has `NoTopology` since points have moved.
+The returned cloud has `NoTopology` since points have moved.
 
 !!! note "Only volume points are repelled"
     Boundary points remain fixed — only volume (interior) points are moved during repulsion. This preserves the original boundary geometry.
 
 !!! tip "Tuning repulsion"
-    The default parameters (`β=0.2`, `k=21`, `max_iters=1000`) work well for most problems. Check `convergence[end]` to verify the distribution has stabilized. See the [Node Repulsion](repel.md) page for detailed parameter guidance.
+    The default parameters (`β=0.2`, `k=21`, `max_iters=1000`) work well for most problems. Check `conv[end]` to verify the distribution has stabilized. See the [Node Repulsion](repel.md) page for detailed parameter guidance.
 
 ### Verifying Distribution Quality
 
@@ -189,5 +193,5 @@ visualize(boundary; markersize=0.15)
 Save a point cloud to VTK format for use in external tools:
 
 ```julia
-export_cloud("output.vtk", cloud)
+save("output", cloud; format = :vtk)
 ```

--- a/docs/src/quickstart.md
+++ b/docs/src/quickstart.md
@@ -27,7 +27,7 @@ spacing = ConstantSpacing(1mm)
 cloud = discretize(boundary, spacing; alg=VanDerSandeFornberg())
 
 # 4. Optimize point distribution
-cloud, convergence = repel(cloud, spacing)
+cloud = repel(cloud, spacing)
 
 # 5. Build neighbor connectivity
 cloud = set_topology(cloud, KNNTopology, 21)
@@ -50,7 +50,7 @@ spacing = ConstantSpacing(0.05m)
 cloud = discretize(boundary, spacing; alg=FornbergFlyer())
 
 # 3. Optimize and connect
-cloud, convergence = repel(cloud, spacing)
+cloud = repel(cloud, spacing)
 cloud = set_topology(cloud, KNNTopology, 9)
 ```
 

--- a/docs/src/repel.md
+++ b/docs/src/repel.md
@@ -11,10 +11,14 @@ Meshless PDE methods (RBF-FD, generalized finite differences) are sensitive to p
 ## Usage
 
 ```julia
-cloud, convergence = repel(cloud, spacing; β=0.2, max_iters=1000)
+cloud = repel(cloud, spacing; β=0.2, max_iters=1000)
+
+# Collect convergence history via keyword
+conv = Float64[]
+cloud = repel(cloud, spacing; β=0.2, max_iters=1000, convergence=conv)
 ```
 
-[`repel`](@ref) returns a tuple of `(new_cloud, convergence_vector)`. The new cloud has [`NoTopology`](@ref) since points have moved — call [`set_topology`](@ref) again after repulsion.
+[`repel`](@ref) returns a new cloud with [`NoTopology`](@ref) since points have moved — call [`set_topology`](@ref) again after repulsion. Pass a `Vector{Float64}` via the `convergence` keyword to collect the convergence history.
 
 !!! note "Boundary points are fixed"
     Only volume (interior) points are moved during repulsion. Boundary points remain in place to preserve the original surface geometry.
@@ -61,7 +65,8 @@ where `r` is the distance to a neighbor. The `β` parameter prevents singularity
 The convergence vector records the maximum relative point displacement at each iteration:
 
 ```julia
-cloud, conv = repel(cloud, spacing; β=0.2, max_iters=500)
+conv = Float64[]
+cloud = repel(cloud, spacing; β=0.2, max_iters=500, convergence=conv)
 
 # Check if converged
 println("Final displacement: ", conv[end])
@@ -81,7 +86,7 @@ Use `metrics` to quantify the point distribution before and after repulsion:
 metrics(cloud)
 
 # After repulsion
-cloud_repelled, conv = repel(cloud, spacing)
+cloud_repelled = repel(cloud, spacing)
 metrics(cloud_repelled)
 ```
 

--- a/src/WhatsThePoint.jl
+++ b/src/WhatsThePoint.jl
@@ -23,7 +23,7 @@ using Unitful
 import Meshes: Manifold, Domain
 import Meshes: centroid, boundingbox, discretize, to, crs
 import Meshes: elements, nelements, lentype, normal, area
-# re-export from Meshes.jl
+# Point, coords, centroid, boundingbox from Meshes.jl; isinside and points defined locally
 export Point, coords, isinside, centroid, boundingbox, points
 export KNearestSearch, BallSearch, MetricBall, search, searchdists
 

--- a/src/WhatsThePoint.jl
+++ b/src/WhatsThePoint.jl
@@ -44,7 +44,6 @@ include("octree/spacing_criterion.jl")
 export TriangleOctree, num_leaves, num_triangles, has_consistent_normals
 
 include("points.jl")
-export emptyspace
 
 include("shadow.jl")
 export ShadowPoints
@@ -56,7 +55,7 @@ export neighbors, hastopology, set_topology, rebuild_topology!
 
 include("surface.jl")
 export AbstractSurface, PointSurface, SurfaceElement
-export point, normal, area
+export normal, area
 
 include("volume.jl")
 export PointVolume
@@ -91,7 +90,7 @@ export repel
 include("metrics.jl")
 
 include("io.jl")
-export import_surface, export_cloud, visualize, save
+export import_surface, visualize, save
 
 # visualize function is defined in WhatsThePointMakieExt when Makie is loaded
 function visualize end

--- a/src/boundary.jl
+++ b/src/boundary.jl
@@ -138,7 +138,7 @@ function Base.getindex(boundary::PointBoundary, index::Int)
         throw(BoundsError(boundary, index))
     end
     name, local_idx = global_to_local(boundary, index)
-    return point(boundary[name])[local_idx]
+    return points(boundary[name])[local_idx]
 end
 function Base.setindex!(boundary::PointBoundary, surf::PointSurface, name::Symbol)
     hassurface(boundary, name) && throw(ArgumentError("surface name already exists."))

--- a/src/boundary.jl
+++ b/src/boundary.jl
@@ -49,19 +49,21 @@ end
 
 """
     PointBoundary(mesh::SimpleMesh)
-Create a `PointBoundary` from a `SimpleMesh` 
-by taking the centroids of its elements as points, 
-and computing normals and areas accordingly.
 
-(IMPORTANT: does not use any fancy node sampling, 
-depends on the mesh's discretization, and is not guaranteed 
-to be a good representation of the original geometry. 
-Use with caution.)
+Create a `PointBoundary` from a `SimpleMesh` by taking the centroids of its
+elements as points, normals directly from mesh face geometry, and areas from
+`Meshes.area`.
+
+Note: depends on the mesh's discretization and is not guaranteed to be a good
+representation of the original geometry. Use with caution.
 """
 function PointBoundary(mesh::SimpleMesh)
     points = map(centroid, elements(mesh))
-    normals = compute_normals(points)
-    normals = map(x -> x / norm(x), normals) # normalize normals
+    normals = map(elements(mesh)) do elem
+        n = Meshes.normal(elem)
+        n_sv = SVector(ustrip(n[1]), ustrip(n[2]), ustrip(n[3]))
+        n_sv / norm(n_sv)
+    end
     areas = map(Meshes.area, elements(mesh))
     return PointBoundary(points, normals, areas)
 end

--- a/src/boundary.jl
+++ b/src/boundary.jl
@@ -61,8 +61,7 @@ function PointBoundary(mesh::SimpleMesh)
     points = map(centroid, elements(mesh))
     normals = map(elements(mesh)) do elem
         n = Meshes.normal(elem)
-        n_sv = SVector(ustrip(n[1]), ustrip(n[2]), ustrip(n[3]))
-        n_sv / norm(n_sv)
+        SVector(ustrip(n[1]), ustrip(n[2]), ustrip(n[3]))
     end
     areas = map(Meshes.area, elements(mesh))
     return PointBoundary(points, normals, areas)

--- a/src/cloud.jl
+++ b/src/cloud.jl
@@ -41,7 +41,7 @@ function Base.getindex(cloud::PointCloud, index::Int)
     if component === :volume
         return volume(cloud)[local_idx]
     else
-        return point(cloud[component])[local_idx]
+        return points(cloud[component])[local_idx]
     end
 end
 function Base.iterate(cloud::PointCloud, state = 1)

--- a/src/discretization/algorithms/octree.jl
+++ b/src/discretization/algorithms/octree.jl
@@ -6,6 +6,11 @@ Spacing-driven volume discretization algorithm.
 **Note:** This is not solution-adaptive (AMR). Refinement is determined a priori
 by a prescribed spacing function, not by computed solution features.
 
+!!! note
+    `Octree` is a **discretization algorithm** that generates volume fill points.
+    [`TriangleOctree`](@ref) is a separate **spatial data structure** used internally
+    for mesh geometry queries. They serve different purposes.
+
 # Algorithm
 Uses dual octrees internally:
 - **Triangle octree**: Captures geometry (surfaces, curvature)

--- a/src/discretization/discretization.jl
+++ b/src/discretization/discretization.jl
@@ -25,6 +25,11 @@ boundary = PointBoundary(mesh)
 octree = TriangleOctree(mesh; min_ratio=1e-6)
 cloud = discretize(boundary, 3.0m; alg=SlakKosec(octree), max_points=100_000)
 ```
+
+!!! note
+    WhatsThePoint's `discretize` generates volume fill points from a boundary.
+    This differs from Meshes.jl's `discretize` which converts continuous geometry
+    into a mesh. No dispatch collision exists — argument types are distinct.
 """
 function discretize(
         bnd::PointBoundary{𝔼{3}},

--- a/src/discretization/spacings.jl
+++ b/src/discretization/spacings.jl
@@ -1,3 +1,16 @@
+"""
+    AbstractSpacing
+
+Interface for spacing functions that control node density during discretization.
+
+Subtypes must be callable with a single `Point` or `Vec` argument and return a `Unitful.Length`
+representing the desired node spacing at that location.
+
+    (s::MySpacing)(p::Union{Point, Vec}) -> Unitful.Length
+
+See [`ConstantSpacing`](@ref), [`LogLike`](@ref), and [`BoundaryLayerSpacing`](@ref) for
+concrete implementations.
+"""
 abstract type AbstractSpacing end
 abstract type VariableSpacing <: AbstractSpacing end
 

--- a/src/io.jl
+++ b/src/io.jl
@@ -20,13 +20,88 @@ function import_surface(filepath::String)
 end
 
 """
-    export_cloud(filename::String, cloud::PointCloud)
+    save(filename::String, cloud::PointCloud; format=:jld2)
 
-Export a point cloud to VTK format. The output file contains boundary point coordinates and
-normal vectors.
+Save a point cloud to a file.
+
+- `format=:jld2` (default): Serialize via FileIO.jl.
+- `format=:vtk`: Export to VTK format with boundary and volume points, normals, and a
+  point type indicator (`1` = boundary, `2` = volume).
 """
-function export_cloud(filename::String, cloud::PointCloud)
-    exportvtk(filename, to(boundary(cloud)), [normal(cloud)], ["normals"])
+function FileIO.save(filename::String, cloud::PointCloud; format::Symbol = :jld2)
+    if format === :jld2
+        return FileIO.save(filename, LittleDict("cloud" => cloud))
+    elseif format === :vtk
+        _save_vtk_cloud(filename, cloud)
+    else
+        throw(ArgumentError("unsupported format: $format. Use :jld2 or :vtk."))
+    end
+    return nothing
+end
+
+function _save_vtk_cloud(filename::String, cloud::PointCloud)
+    bnd_pts = to(boundary(cloud))
+    vol_pts = length(volume(cloud)) > 0 ? to(volume(cloud)) : eltype(bnd_pts)[]
+    all_pts = vcat(bnd_pts, vol_pts)
+
+    nbnd = length(bnd_pts)
+    nvol = length(vol_pts)
+
+    # type indicator: 1 = boundary, 2 = volume
+    point_type = vcat(ones(Int, nbnd), fill(2, nvol))
+
+    # normals: boundary has normals, volume gets zeros
+    bnd_normals = normal(boundary(cloud))
+    zero_normal = zero(first(bnd_normals))
+    vol_normals = fill(zero_normal, nvol)
+    all_normals = vcat(bnd_normals, vol_normals)
+
+    exportvtk(
+        filename, all_pts,
+        [all_normals, point_type],
+        ["normals", "point_type"],
+    )
+    return nothing
+end
+
+"""
+    save(filename::String, boundary::PointBoundary; format=:jld2)
+
+Save a boundary to a file.
+
+- `format=:jld2` (default): Serialize via FileIO.jl.
+- `format=:vtk`: Export to VTK format with boundary points and normals.
+"""
+function FileIO.save(filename::String, bnd::PointBoundary; format::Symbol = :jld2)
+    if format === :jld2
+        return FileIO.save(filename, LittleDict("boundary" => bnd))
+    elseif format === :vtk
+        exportvtk(filename, to(bnd), [normal(bnd)], ["normals"])
+    else
+        throw(ArgumentError("unsupported format: $format. Use :jld2 or :vtk."))
+    end
+    return nothing
+end
+
+"""
+    save(filename::String, surf::PointSurface; format=:jld2)
+
+Save a surface to a file.
+
+- `format=:jld2` (default): Serialize via FileIO.jl.
+- `format=:vtk`: Export to VTK format with surface points, normals, and areas.
+"""
+function FileIO.save(filename::String, surf::PointSurface; format::Symbol = :jld2)
+    if format === :jld2
+        return FileIO.save(filename, LittleDict("surface" => surf))
+    elseif format === :vtk
+        a = area(surf)
+        data = isnothing(a) ? [normal(surf)] : [normal(surf), ustrip.(a)]
+        names = isnothing(a) ? ["normals"] : ["normals", "areas"]
+        exportvtk(filename, to(surf), data, names)
+    else
+        throw(ArgumentError("unsupported format: $format. Use :jld2 or :vtk."))
+    end
     return nothing
 end
 
@@ -68,13 +143,4 @@ _hcat_data(data::AbstractVector) = reduce(hcat, data)
 
 function savevtk!(vtkfile)
     return vtk_save(vtkfile)
-end
-
-"""
-    save(filename::String, cloud::PointCloud)
-
-Save a point cloud to a file using FileIO.jl serialization.
-"""
-function FileIO.save(filename::String, cloud::PointCloud)
-    return save(filename, LittleDict("cloud" => cloud))
 end

--- a/src/isinside.jl
+++ b/src/isinside.jl
@@ -24,7 +24,7 @@ function isinside(testpoint::Point{𝔼{2}}, cloud::PointCloud{𝔼{2}})
 end
 
 function isinside(testpoint::Point{𝔼{2}}, surf::PointSurface{𝔼{2}})
-    return isinside(testpoint, point(surf))
+    return isinside(testpoint, points(surf))
 end
 
 function isinside(testpoint::AbstractVector, surf::PointSurface{𝔼{Dim}}) where {Dim}

--- a/src/isinside.jl
+++ b/src/isinside.jl
@@ -1,5 +1,22 @@
+"""
+    isinside(testpoint::Point{𝔼{2}}, pts::AbstractVector{<:Point{𝔼{2}}}) -> Bool
+    isinside(testpoint::Point{𝔼{N}}, cloud::Union{PointCloud, PointBoundary}) -> Bool
+
+Test whether `testpoint` lies inside the closed domain defined by the boundary points.
+
+For 2D, uses the winding number algorithm — `pts` must be ordered sequentially around
+the polygon boundary (clockwise or counter-clockwise). An `ArgumentError` is thrown
+if the points do not form a valid ordered polygon.
+
+For 3D, uses a Green's function approach over the boundary surfaces.
+
+!!! note
+    WhatsThePoint's `isinside` tests point-in-polygon/volume membership for meshless
+    point clouds. This is distinct from Meshes.jl's `isinside` which operates on
+    geometric domain objects. No dispatch collision exists — argument types differ.
+"""
 function isinside(testpoint::Point{𝔼{2}}, pts::AbstractVector{<:Point{𝔼{2}, C}}) where {C}
-    # WARNING: this only works if the points are ordered in a loop...
+    _validate_polygon_ordering(pts)
 
     # first check if point is coincident with any surf surface point and return true if so
     r = map(p -> norm(p - testpoint), pts)
@@ -13,10 +30,41 @@ function isinside(testpoint::Point{𝔼{2}}, pts::AbstractVector{<:Point{𝔼{2}
     # compute last segment from last point to first to complete the loop
     sumangles += ∠(pts[end], testpoint, pts[1])
 
-    # TODO need to add a check if a multiple of 2*pi or 0 ??? does this make sense
-
     # if point is inside, sum of angles is 2pi, if outside, sum of angles is 0.
     return abs(sumangles) < (1.0e3 * eps(T) * Unitful.rad) ? false : true
+end
+
+function _validate_polygon_ordering(pts::AbstractVector{<:Point{𝔼{2}, C}}) where {C}
+    n = length(pts)
+    n < 3 && throw(ArgumentError(
+        "need at least 3 points to define a polygon, got $n"
+    ))
+    # Signed area via shoelace formula — zero area indicates self-intersecting
+    # (unordered) vertices or collinear points
+    T = CoordRefSystems.mactype(C)
+    sa = zero(T)
+    xmin = xmax = ustrip(to(pts[1])[1])
+    ymin = ymax = ustrip(to(pts[1])[2])
+    for i in 1:n
+        j = mod1(i + 1, n)
+        xi, yi = ustrip(to(pts[i])[1]), ustrip(to(pts[i])[2])
+        xj, yj = ustrip(to(pts[j])[1]), ustrip(to(pts[j])[2])
+        sa += xi * yj - xj * yi
+        xmin = min(xmin, xi)
+        xmax = max(xmax, xi)
+        ymin = min(ymin, yi)
+        ymax = max(ymax, yi)
+    end
+    sa /= 2
+    bbox_area = (xmax - xmin) * (ymax - ymin)
+    if bbox_area > zero(T) && abs(sa) < T(1e-10) * bbox_area
+        throw(ArgumentError(
+            "polygon points do not appear to be ordered sequentially around the boundary; " *
+            "the 2D isinside winding number algorithm requires points ordered in a loop " *
+            "(clockwise or counter-clockwise)"
+        ))
+    end
+    return nothing
 end
 
 function isinside(testpoint::Point{𝔼{2}}, cloud::PointCloud{𝔼{2}})

--- a/src/isinside.jl
+++ b/src/isinside.jl
@@ -36,9 +36,11 @@ end
 
 function _validate_polygon_ordering(pts::AbstractVector{<:Point{𝔼{2}, C}}) where {C}
     n = length(pts)
-    n < 3 && throw(ArgumentError(
-        "need at least 3 points to define a polygon, got $n"
-    ))
+    n < 3 && throw(
+        ArgumentError(
+            "need at least 3 points to define a polygon, got $n"
+        )
+    )
     # Signed area via shoelace formula — zero area indicates self-intersecting
     # (unordered) vertices or collinear points
     T = CoordRefSystems.mactype(C)
@@ -57,12 +59,14 @@ function _validate_polygon_ordering(pts::AbstractVector{<:Point{𝔼{2}, C}}) wh
     end
     sa /= 2
     bbox_area = (xmax - xmin) * (ymax - ymin)
-    if bbox_area > zero(T) && abs(sa) < T(1e-10) * bbox_area
-        throw(ArgumentError(
-            "polygon points do not appear to be ordered sequentially around the boundary; " *
-            "the 2D isinside winding number algorithm requires points ordered in a loop " *
-            "(clockwise or counter-clockwise)"
-        ))
+    if bbox_area > zero(T) && abs(sa) < T(1.0e-10) * bbox_area
+        throw(
+            ArgumentError(
+                "polygon points do not appear to be ordered sequentially around the boundary; " *
+                    "the 2D isinside winding number algorithm requires points ordered in a loop " *
+                    "(clockwise or counter-clockwise)"
+            )
+        )
     end
     return nothing
 end

--- a/src/metrics.jl
+++ b/src/metrics.jl
@@ -1,18 +1,24 @@
 """
     metrics(cloud::PointCloud; k=20)
 
-Print distance statistics (mean, std, max, min) to the `k` nearest neighbors for all points
+Compute distance statistics (mean, std, max, min) to the `k` nearest neighbors for all points
 in the cloud. Useful for assessing point distribution quality before and after repulsion.
+
+Returns a `NamedTuple` with fields `avg`, `std`, `max`, `min`, and `k`.
 """
 function metrics(cloud::PointCloud; k = 20)
     method = KNearestSearch(cloud, k)
     results = searchdists(cloud, method)
     r = map(x -> x[2][2:end], results) # x[2] = distances, [2:end] skips self
+    avg = mean(mean.(r))
+    σ = mean(std.(r))
+    mx = mean(maximum.(r))
+    mn = mean(minimum.(r))
     println("Cloud Metrics")
     println("-------------")
-    println("avg. distance to $k nearest neighbors: $(mean(mean.(r)))")
-    println("std. distance to $k nearest neighbors: $(mean(std.(r)))")
-    println("max. distance to $k nearest neighbors: $(mean(maximum.(r)))")
-    println("min. distance to $k nearest neighbors: $(mean(minimum.(r)))")
-    return nothing
+    println("avg. distance to $k nearest neighbors: $avg")
+    println("std. distance to $k nearest neighbors: $σ")
+    println("max. distance to $k nearest neighbors: $mx")
+    println("min. distance to $k nearest neighbors: $mn")
+    return (; avg, std = σ, max = mx, min = mn, k)
 end

--- a/src/normals.jl
+++ b/src/normals.jl
@@ -8,8 +8,8 @@ Requires Euclidean manifold (`𝔼{2}` or `𝔼{3}`). This function assumes flat
 """
 function compute_normals(surf::PointSurface{𝔼{N}, C}; k::Int = 5) where {N, C <: CRS}
     k = k > length(surf) ? length(surf) : k
-    points = point(surf)
-    return compute_normals(points; k = k)
+    pts = points(surf)
+    return compute_normals(pts; k = k)
 end
 
 function compute_normals(points::AbstractVector{<:Point{𝔼{N}}}; k::Int = 5) where {N}
@@ -31,7 +31,7 @@ function compute_normals(
         search_method::KNearestSearch,
         surf::PointSurface{𝔼{N}, C},
     ) where {N, C <: CRS}
-    return compute_normals(search_method, point(surf))
+    return compute_normals(search_method, points(surf))
 end
 
 function compute_normals(
@@ -55,8 +55,8 @@ function update_normals!(surf::PointSurface{𝔼{N}, C}; k::Int = 5) where {N, C
     k = k > length(surf) ? length(surf) : k
     neighbors = search(surf, KNearestSearch(surf, k))
     normals = normal(surf)
-    points = point(surf)
-    return tmap!(n -> _compute_normal(points[n]), normals, neighbors)
+    pts = points(surf)
+    return tmap!(n -> _compute_normal(pts[n]), normals, neighbors)
 end
 
 function _compute_normal(points::AbstractVector{<:Point{𝔼{N}}}) where {N}
@@ -137,7 +137,7 @@ end
 
 function orient_normals!(surf::PointSurface{𝔼{N}, C}; k::Int = 5) where {N, C <: CRS}
     k = k > length(surf) ? length(surf) : k
-    return orient_normals!(normal(surf), point(surf); k = k)
+    return orient_normals!(normal(surf), points(surf); k = k)
 end
 
 function orient_normals!(cloud::PointCloud{𝔼{N}, C}; k::Int = 5) where {N, C <: CRS}

--- a/src/octree/spacing_criterion.jl
+++ b/src/octree/spacing_criterion.jl
@@ -114,7 +114,30 @@ function _box_may_contain_interior(node_tree, box_idx, triangle_octree)
     for pt in (center, corners...)
         _mesh_geometry_query(pt, tol, triangle_octree) != LEAF_EXTERIOR && return true
     end
+
+    # Point sampling can miss thin/elongated domains inside large cubic boxes.
+    # Fall back to checking whether any non-exterior triangle-octree leaf overlaps this box.
+    tri_tree = triangle_octree.tree
+    tri_cls = triangle_octree.leaf_classification
+    if !isnothing(tri_cls)
+        for leaf_idx in all_leaves(tri_tree)
+            tri_cls[leaf_idx] == LEAF_EXTERIOR && continue
+            leaf_min, leaf_max = box_bounds(tri_tree, leaf_idx)
+            if _boxes_overlap(bbox_min, bbox_max, leaf_min, leaf_max)
+                return true
+            end
+        end
+    end
+
     return false
+end
+
+@inline function _boxes_overlap(a_min, a_max, b_min, b_max)
+    @inbounds for d in 1:3
+        a_min[d] > b_max[d] && return false
+        a_max[d] < b_min[d] && return false
+    end
+    return true
 end
 
 function _subdivide_node_octree!(node_tree, box_idx, criterion, triangle_octree)

--- a/src/repel.jl
+++ b/src/repel.jl
@@ -1,10 +1,11 @@
 """
-    repel(cloud::PointCloud, spacing; β=0.2, α=auto, k=21, max_iters=1000, tol=1e-6)
+    repel(cloud::PointCloud, spacing; β=0.2, α=auto, k=21, max_iters=1000, tol=1e-6, convergence=nothing)
 
 Optimize point distribution via node repulsion (Miotti 2023).
-Returns `(new_cloud, convergence_vector)` tuple.
 
 The returned cloud has `NoTopology` since points have moved.
+
+Pass a `Vector{Float64}` via the `convergence` keyword to collect the convergence history.
 """
 function repel(
         cloud::PointCloud{𝔼{N}, C},
@@ -14,6 +15,7 @@ function repel(
         k = 21,
         max_iters = 1000,
         tol = 1.0e-6,
+        convergence::Union{Nothing, AbstractVector{<:AbstractFloat}} = nothing,
     ) where {N, C <: CRS}
     # Miotti 2023
     α = ustrip(α)
@@ -24,7 +26,7 @@ function repel(
     method = KNearestSearch(all_p, k)
 
     vol_spacings = ustrip.(spacing.(p))
-    convergence = let s = vol_spacings
+    convergence_fn = let s = vol_spacings
         (p, p_old) -> norm(ustrip.(norm.(p .- p_old)) ./ s, Inf)
     end
 
@@ -50,7 +52,7 @@ function repel(
 
             return xi + Vec(s * α * repel_force)
         end
-        push!(conv, convergence(p, p_old))
+        push!(conv, convergence_fn(p, p_old))
         if conv[end] < tol
             println("Node repel finished in $i iterations. Convergence = $(conv[end])")
             break
@@ -60,7 +62,9 @@ function repel(
     if i == max_iters
         @warn "Node repel reached maximum number of iterations ($max_iters), Convergence = ($(conv[end]))\n"
     end
+    if !isnothing(convergence)
+        append!(convergence, conv)
+    end
     new_volume = PointVolume(filter(x -> isinside(x, cloud), p))
-    new_cloud = PointCloud(boundary(cloud), new_volume, NoTopology())
-    return (new_cloud, conv)
+    return PointCloud(boundary(cloud), new_volume, NoTopology())
 end

--- a/src/surface.jl
+++ b/src/surface.jl
@@ -101,13 +101,13 @@ end
 """
     points(surf::PointSurface)
 
-Return vector of points from surface. Alias for `point(surf)`.
+Return vector of point coordinates for all surface elements.
 """
-points(surf::PointSurface) = point(surf)
+points(surf::PointSurface) = parent(surf).point
 Meshes.elements(surf::PointSurface) = (elem for elem in parent(surf))
 Meshes.nelements(surf::PointSurface) = length(parent(surf))
-Meshes.centroid(surf::PointSurface) = centroid(point(surf))
-Meshes.boundingbox(surf::PointSurface) = boundingbox(point(surf))
+Meshes.centroid(surf::PointSurface) = centroid(points(surf))
+Meshes.boundingbox(surf::PointSurface) = boundingbox(points(surf))
 
 ChunkSplitters.is_chunkable(::PointSurface) = true
 
@@ -115,13 +115,6 @@ Base.view(surf::PointSurface, range::UnitRange) = view(parent(surf), range)
 Base.view(surf::PointSurface, range::StepRange) = view(parent(surf), range)
 
 to(surf::PointSurface) = to.(parent(surf).point)
-
-"""
-    point(surf::PointSurface)
-
-Return the vector of point coordinates for all surface elements.
-"""
-point(surf::PointSurface) = parent(surf).point
 
 """
     normal(surf::PointSurface)
@@ -176,7 +169,7 @@ function set_topology(surf::PointSurface, ::Type{KNNTopology}, k::Int)
     adj = _build_knn_neighbors(pts, k)
     topo = KNNTopology(adj, k)
     return PointSurface(
-        point(surf),
+        points(surf),
         normal(surf),
         area(surf);
         topology = topo,
@@ -193,7 +186,7 @@ function set_topology(surf::PointSurface, ::Type{RadiusTopology}, radius)
     adj = _build_radius_neighbors(pts, radius)
     topo = RadiusTopology(adj, radius)
     return PointSurface(
-        point(surf),
+        points(surf),
         normal(surf),
         area(surf);
         topology = topo,

--- a/src/surface_operations.jl
+++ b/src/surface_operations.jl
@@ -61,7 +61,7 @@ function split_surface!(
         angle::Angle;
         k::Int = 10,
     )
-    points = point(surf)
+    pts = points(surf)
     normals = normal(surf)
     areas = area(surf)
 
@@ -78,13 +78,13 @@ function split_surface!(
     connec = connected_components(g)
     ranges = ranges_from_permutation(connec)
 
-    many_permute!(points, connec, ranges)
+    many_permute!(pts, connec, ranges)
     many_permute!(normals, connec, ranges)
     many_permute!(areas, connec, ranges)
 
     for (i, ids) in enumerate(ranges)
         name = _generate_surface_name(cloud, i)
-        cloud[name] = PointSurface(points[ids], normals[ids], areas[ids])
+        cloud[name] = PointSurface(pts[ids], normals[ids], areas[ids])
     end
 
     return cloud

--- a/test/boundary.jl
+++ b/test/boundary.jl
@@ -3,7 +3,7 @@
     pts = rand(Point, N)
     b = PointBoundary(pts)
     @test all(points(b) .== pts)
-    @test point(b[:surface1]) == pts
+    @test points(b[:surface1]) == pts
 end
 
 @testitem "PointBoundary from file" setup = [TestData, CommonImports] begin
@@ -27,22 +27,22 @@ end
     @test_throws BoundsError b[N + 1]
     @test_throws BoundsError b[N + 100]
 
-    points = rand(Point, N)
-    surf = PointSurface(points)
+    pts2 = rand(Point, N)
+    surf = PointSurface(pts2)
     @test_throws ArgumentError b[:surface1] = surf
     b[:surface2] = surf
     @test b[:surface2] == surf
 
     # Test indexing across multiple surfaces (exercises offset += length(surf))
     @test b[N + 1] isa Point  # Access first element of surface2
-    @test b[N + 1] == point(surf)[1]  # Verify correct value via offset
+    @test b[N + 1] == points(surf)[1]  # Verify correct value via offset
     @test b[N + 5] isa Point  # Access later element in surface2
 
     @testset "iterate" begin
-        points = rand(Point, N)
-        b = PointBoundary(points)
+        iter_pts = rand(Point, N)
+        b = PointBoundary(iter_pts)
         for (i, p) in enumerate(b)
-            @test p == points[i]
+            @test p == iter_pts[i]
         end
     end
 end
@@ -56,7 +56,7 @@ end
     surf2 = PointSurface(points2)
     @test_nowarn b[:newsurface] = surf2
     @test hassurface(b, :newsurface)
-    @test point(b[:newsurface]) == points2
+    @test points(b[:newsurface]) == points2
 
     @test_throws ArgumentError b[:newsurface] = surf2
 end

--- a/test/boundary.jl
+++ b/test/boundary.jl
@@ -12,9 +12,20 @@ end
     @test hassurface(b, :surface1)
 end
 
-@testitem "PointBoundary source_mesh" setup = [TestData, CommonImports] begin
-    # TODO: has_source_mesh/source_mesh/NoMesh not yet implemented
-    @test_skip "has_source_mesh not yet implemented"
+@testitem "PointBoundary from SimpleMesh uses mesh normals" setup = [OctreeTestData, CommonImports] begin
+    mesh = OctreeTestData.unit_cube_mesh()
+    b = PointBoundary(mesh)
+    @test length(b) == 12
+
+    norms = normal(b)
+    for n in norms
+        # Each normal should be axis-aligned (one component ≈ ±1, others ≈ 0)
+        sorted = sort(abs.(n))
+        @test sorted[1] < 0.01
+        @test sorted[2] < 0.01
+        @test isapprox(sorted[3], 1.0; atol = 0.01)
+    end
+    @test all(n -> isapprox(norm(n), 1.0; atol = 1e-10), norms)
 end
 
 @testitem "PointBoundary Base Methods" setup = [TestData, CommonImports] begin

--- a/test/boundary.jl
+++ b/test/boundary.jl
@@ -25,7 +25,7 @@ end
         @test sorted[2] < 0.01
         @test isapprox(sorted[3], 1.0; atol = 0.01)
     end
-    @test all(n -> isapprox(norm(n), 1.0; atol = 1e-10), norms)
+    @test all(n -> isapprox(norm(n), 1.0; atol = 1.0e-10), norms)
 end
 
 @testitem "PointBoundary Base Methods" setup = [TestData, CommonImports] begin

--- a/test/io.jl
+++ b/test/io.jl
@@ -15,13 +15,36 @@
     @test all(a -> Unitful.ustrip(a) > 0, areas)
 end
 
-@testitem "export_cloud" setup = [TestData, CommonImports] begin
+@testitem "save VTK cloud" setup = [TestData, CommonImports] begin
     boundary = PointBoundary(TestData.BOX_PATH)
     cloud = PointCloud(boundary)
 
     mktempdir() do tmpdir
         filename = joinpath(tmpdir, "test_export")
-        export_cloud(filename, cloud)
+        save(filename, cloud; format = :vtk)
+
+        @test isfile(filename * ".vtu")
+    end
+end
+
+@testitem "save VTK boundary" setup = [TestData, CommonImports] begin
+    boundary = PointBoundary(TestData.BOX_PATH)
+
+    mktempdir() do tmpdir
+        filename = joinpath(tmpdir, "test_boundary")
+        save(filename, boundary; format = :vtk)
+
+        @test isfile(filename * ".vtu")
+    end
+end
+
+@testitem "save VTK surface" setup = [TestData, CommonImports] begin
+    boundary = PointBoundary(TestData.BOX_PATH)
+    surf = boundary[:surface1]
+
+    mktempdir() do tmpdir
+        filename = joinpath(tmpdir, "test_surface")
+        save(filename, surf; format = :vtk)
 
         @test isfile(filename * ".vtu")
     end
@@ -53,11 +76,11 @@ end
         original_length = length(cloud)
 
         vtk_filename = joinpath(tmpdir, "roundtrip_test")
-        export_cloud(vtk_filename, cloud)
+        save(vtk_filename, cloud; format = :vtk)
         @test isfile(vtk_filename * ".vtu")
 
         jld2_filename = joinpath(tmpdir, "roundtrip_test.jld2")
-        FileIO.save(jld2_filename, cloud)
+        save(jld2_filename, cloud)
         @test isfile(jld2_filename)
 
         loaded = FileIO.load(jld2_filename)

--- a/test/isinside.jl
+++ b/test/isinside.jl
@@ -48,6 +48,16 @@ end
     @test_throws MethodError isinside([0.5, 0.5], surf)
 end
 
+@testitem "isinside 2D throws on unordered points" setup = [TestData, CommonImports] begin
+    pts = Point.([(0, 0), (1, 1), (1, 0), (0, 1)])
+    @test_throws ArgumentError isinside(Point(0.5, 0.5), pts)
+end
+
+@testitem "isinside 2D throws on too few points" setup = [TestData, CommonImports] begin
+    pts = Point.([(0, 0), (1, 0)])
+    @test_throws ArgumentError isinside(Point(0.5, 0.5), pts)
+end
+
 @testitem "isinside 3D PointBoundary" setup = [TestData, CommonImports] begin
     boundary = PointBoundary(TestData.BOX_PATH)
     @test isinside(Point(0.5, 0.5, 0.5), boundary)

--- a/test/metrics.jl
+++ b/test/metrics.jl
@@ -21,7 +21,12 @@
     @test occursin("max. distance to 20 nearest neighbors", output)
     @test occursin("min. distance to 20 nearest neighbors", output)
 
-    @test result === nothing
+    @test result isa NamedTuple
+    @test haskey(result, :avg)
+    @test haskey(result, :std)
+    @test haskey(result, :max)
+    @test haskey(result, :min)
+    @test haskey(result, :k)
 end
 
 @testitem "metrics with custom k" setup = [TestData, CommonImports] begin
@@ -47,7 +52,12 @@ end
     @test occursin("max. distance to 10 nearest neighbors", output)
     @test occursin("min. distance to 10 nearest neighbors", output)
 
-    @test result === nothing
+    @test result isa NamedTuple
+    @test haskey(result, :avg)
+    @test haskey(result, :std)
+    @test haskey(result, :max)
+    @test haskey(result, :min)
+    @test haskey(result, :k)
 end
 
 @testitem "metrics with small k" setup = [TestData, CommonImports] begin
@@ -68,7 +78,12 @@ end
 
     @test output isa String
     @test occursin("avg. distance to 5 nearest neighbors", output)
-    @test result === nothing
+    @test result isa NamedTuple
+    @test haskey(result, :avg)
+    @test haskey(result, :std)
+    @test haskey(result, :max)
+    @test haskey(result, :min)
+    @test haskey(result, :k)
 end
 
 @testitem "metrics statistics verification" setup = [TestData, CommonImports] begin
@@ -114,9 +129,15 @@ end
 
     output, result = capture_stdout(() -> metrics(small_cloud; k = 10))
     @test occursin("Cloud Metrics", output)
-    @test result === nothing
+    @test result isa NamedTuple
+    @test haskey(result, :avg)
+    @test haskey(result, :std)
+    @test haskey(result, :max)
+    @test haskey(result, :min)
+    @test haskey(result, :k)
 
     output2, result2 = capture_stdout(() -> metrics(small_cloud; k = 20))
     @test occursin("Cloud Metrics", output2)
-    @test result2 === nothing
+    @test result2 isa NamedTuple
+    @test result2.k == 20
 end

--- a/test/points.jl
+++ b/test/points.jl
@@ -1,4 +1,4 @@
-@testitem "emptyspace" setup = [TestData, CommonImports] begin
+@testitem "WhatsThePoint.emptyspace" setup = [TestData, CommonImports] begin
     square2D = Point.([(0, 0), (1, 1), (0, 1), (1, 0)])
     square3D = Point.(
         [
@@ -13,7 +13,7 @@
         ]
     )
 
-    @test emptyspace(Point(0.5, 0.5), square2D, eps() * m) == true
-    @test emptyspace(Point(0.5, 0.5), square2D, 1m) == false
-    @test emptyspace(square2D, Point(0.5, 0.5), 1m) == false
+    @test WhatsThePoint.emptyspace(Point(0.5, 0.5), square2D, eps() * m) == true
+    @test WhatsThePoint.emptyspace(Point(0.5, 0.5), square2D, 1m) == false
+    @test WhatsThePoint.emptyspace(square2D, Point(0.5, 0.5), 1m) == false
 end

--- a/test/repel.jl
+++ b/test/repel.jl
@@ -6,7 +6,8 @@
     cloud = discretize(boundary, spacing; alg = SlakKosec(octree), max_points = 20)
 
     # Use very high tolerance so it converges immediately
-    new_cloud, conv = repel(cloud, spacing; max_iters = 100, tol = 1000.0)
+    conv = Float64[]
+    new_cloud = repel(cloud, spacing; max_iters = 100, tol = 1000.0, convergence = conv)
 
     @test conv isa Vector{<:AbstractFloat}
     @test length(conv) < 100  # Should converge before max_iters
@@ -24,7 +25,8 @@ end
     original_points = deepcopy(collect(volume(cloud).points))
     original_count = length(volume(cloud))
 
-    new_cloud, conv = repel(cloud, spacing; max_iters = 10)
+    conv = Float64[]
+    new_cloud = repel(cloud, spacing; max_iters = 10, convergence = conv)
 
     # Return type checks
     @test conv isa Vector{<:AbstractFloat}
@@ -58,12 +60,14 @@ end
     octree = TriangleOctree(TestData.BOX_PATH; classify_leaves = true)
     spacing = _relative_spacing(boundary)
 
+    conv1 = Float64[]
     cloud1 = discretize(boundary, spacing; alg = SlakKosec(octree), max_points = 50)
-    _, conv1 = repel(cloud1, spacing; max_iters = 3)
+    repel(cloud1, spacing; max_iters = 3, convergence = conv1)
     @test length(conv1) <= 3
 
+    conv2 = Float64[]
     cloud2 = discretize(boundary, spacing; alg = SlakKosec(octree), max_points = 50)
-    _, conv2 = repel(cloud2, spacing; max_iters = 10)
+    repel(cloud2, spacing; max_iters = 10, convergence = conv2)
     @test length(conv2) <= 10
 end
 
@@ -74,7 +78,8 @@ end
     cloud = discretize(boundary, spacing; alg = SlakKosec(octree), max_points = 30)
 
     # Test all parameters together in one call
-    new_cloud, conv = repel(cloud, spacing; β = 0.3, tol = 1.0e-5, max_iters = 5)
+    conv = Float64[]
+    new_cloud = repel(cloud, spacing; β = 0.3, tol = 1.0e-5, max_iters = 5, convergence = conv)
 
     @test conv isa Vector{<:AbstractFloat}
     @test length(conv) <= 5

--- a/test/surface.jl
+++ b/test/surface.jl
@@ -1,20 +1,20 @@
 @testitem "PointSurface Constructors" setup = [TestData, CommonImports] begin
-    points = rand(Point, 10)
+    pts = rand(Point, 10)
     normals = [Vec(rand(3)...) for _ in 1:10]
     areas = rand(10) * m^2
 
-    geoms = StructArray{SurfaceElement}((points, normals, areas))
+    geoms = StructArray{SurfaceElement}((pts, normals, areas))
     surf = PointSurface(geoms, NoTopology())
 
-    surf = PointSurface(points, normals, areas)
+    surf = PointSurface(pts, normals, areas)
     @test length(surf) == 10
     @test surf.geoms isa StructVector
 
-    surf = PointSurface(points, normals)
+    surf = PointSurface(pts, normals)
     @test length(surf) == 10
     @test surf.geoms isa StructVector
 
-    surf = PointSurface(points)
+    surf = PointSurface(pts)
     @test length(surf) == 10
     @test surf.geoms isa StructVector
 
@@ -23,16 +23,16 @@
     @test surf.geoms isa StructVector
 
     # Test constructor from SubDomain (view of a Domain)
-    domain = PointSet(points)
+    domain = PointSet(pts)
     subdomain = view(domain, 1:5)
     surf_from_subdomain = PointSurface(subdomain, normals[1:5], areas[1:5])
     @test length(surf_from_subdomain) == 5
-    @test point(surf_from_subdomain) == points[1:5]
+    @test points(surf_from_subdomain) == pts[1:5]
 
     # Test _get_underlying_vector with AbstractVector passthrough
-    surf_from_vec = PointSurface(points, normals, areas)
+    surf_from_vec = PointSurface(pts, normals, areas)
     @test length(surf_from_vec) == 10
-    @test point(surf_from_vec) == points
+    @test points(surf_from_vec) == pts
 end
 
 @testitem "SurfaceElement Constructors" setup = [TestData, CommonImports] begin
@@ -56,24 +56,24 @@ end
 end
 
 @testitem "PointSurface Properties" setup = [TestData, CommonImports] begin
-    points = rand(Point, 10)
+    pts = rand(Point, 10)
     normals = [Vec(rand(3)...) for _ in 1:10]
     areas = rand(10) * m^2
 
-    surf = PointSurface(points, normals, areas)
+    surf = PointSurface(pts, normals, areas)
     @test to(surf) == to.(surf.geoms.point)
-    @test point(surf) == surf.geoms.point
+    @test points(surf) == surf.geoms.point
     @test normal(surf) == surf.geoms.normal
     @test area(surf) == surf.geoms.area
     @test parent(surf) == surf.geoms
 end
 
 @testitem "PointSurface Base Methods" setup = [TestData, CommonImports] begin
-    points = rand(Point, 10)
+    pts = rand(Point, 10)
     normals = [Vec(rand(3)...) for _ in 1:10]
     areas = rand(10) * m^2
 
-    surf = PointSurface(points, normals, areas)
+    surf = PointSurface(pts, normals, areas)
     @test length(surf) == 10
     @test firstindex(surf) == 1
     @test lastindex(surf) == 10
@@ -91,7 +91,7 @@ end
     surf = PointSurface(pts_data, normals, areas)
 
     pts = points(surf)
-    @test pts == point(surf)
+    @test pts == parent(surf).point
     @test length(pts) == 10
 
     @test collect(Meshes.elements(surf)) == collect(surf.geoms)

--- a/test/surface_operations.jl
+++ b/test/surface_operations.jl
@@ -7,11 +7,11 @@
     surf2 = PointSurface(points2)
     @test_nowarn b[:newsurface] = surf2
     @test hassurface(b, :newsurface)
-    @test point(b[:newsurface]) == points2
+    @test points(b[:newsurface]) == points2
 
     @test_throws ArgumentError b[:newsurface] = surf2
 
-    @test point(b[:surface1]) == points1
+    @test points(b[:surface1]) == points1
 end
 
 @testitem "combine_surfaces!" setup = [TestData, CommonImports] begin


### PR DESCRIPTION
## Summary

- **Unified accessor naming**: `point(surf)` → `points(surf)` throughout; removed `point` export and `emptyspace` export (now internal)
- **Consolidated save/export API**: replaced `export_cloud` with `save(filename, obj; format=:jld2/:vtk)` supporting `PointCloud`, `PointBoundary`, and `PointSurface`
- **Simplified `repel` return**: returns just the new cloud instead of `(cloud, convergence)` tuple; convergence history collected via `convergence` keyword argument
- **`metrics` returns data**: returns a `NamedTuple` with `avg`, `std`, `max`, `min`, `k` fields instead of `nothing`
- **Mesh normal handling**: `PointBoundary(mesh)` now uses mesh face normals directly instead of recomputing via PCA
- **Input validation**: added polygon ordering validation for 2D `isinside` (winding number requires ordered points)
- **Octree fix**: improved `_box_may_contain_interior` to detect thin/elongated interior regions missed by point sampling
- **Docs**: added disambiguation notes for `discretize` and `isinside` vs Meshes.jl, docstrings for `AbstractSpacing`, clarified mutation conventions