### PR TITLE
fix(octree): filter interior and deficit points with isinside (#76)

### DIFF
--- a/src/discretization/algorithms/octree.jl
+++ b/src/discretization/algorithms/octree.jl
@@ -356,54 +356,37 @@ function _discretize_volume(
     n_near_surface = max_points - n_interior
     println("  Allocating $n_interior interior + $n_near_surface near-surface points")
 
-    # Generate points
+    # Generate points. Interior leaves are trusted after classify_node_octree
+    # demotes any leaf overlapping a triangle-octree boundary leaf, so samples
+    # drawn from LEAF_INTERIOR (and the deficit fill, which pulls from the same
+    # pool) do not need a per-point isinside check.
     raw_points = SVector{3, T}[]
     sizehint!(raw_points, max_points)
 
-    # Interior candidates need the same isinside filter as near-surface:
-    # for high-aspect-ratio domains, cubic octree leaves classified as interior
-    # can extend beyond the actual geometry, so unchecked samples land outside.
-    n_interior_candidates = round(Int, n_interior * alg.boundary_oversampling)
-    print("  Generating interior candidates...")
-    t4 = @elapsed interior_candidates = _generate_from_leaves(interior, node_tree, n_interior_candidates, alg.placement)
-    println(" done ($(length(interior_candidates)) candidates, $(round(t4, digits = 2))s)")
-
-    print("  Filtering interior candidates (isinside check)...")
-    n_interior_accepted = 0
-    t4f = @elapsed begin
-        for p in interior_candidates
-            length(raw_points) >= n_interior && break
-            if isinside(p, alg.triangle_octree)
-                push!(raw_points, p)
-                n_interior_accepted += 1
-            end
-        end
-    end
-    println(" done ($n_interior_accepted accepted, $(round(t4f, digits = 2))s)")
+    print("  Generating interior points...")
+    t4 = @elapsed interior_points = _generate_from_leaves(interior, node_tree, n_interior, alg.placement)
+    println(" done ($(length(interior_points)) points, $(round(t4, digits = 2))s)")
+    append!(raw_points, interior_points)
 
     n_candidates = round(Int, n_near_surface * alg.boundary_oversampling)
     print("  Generating near-surface candidates...")
     t5 = @elapsed candidates = _generate_from_leaves(near_surface, node_tree, n_candidates, alg.placement)
     println(" done ($(length(candidates)) candidates, $(round(t5, digits = 2))s)")
 
-    # Filter candidates
     print("  Filtering candidates (isinside check)...")
-    n_accepted = 0
     t6 = @elapsed begin
-        for p in candidates
-            if isinside(p, alg.triangle_octree)
-                push!(raw_points, p)
-                n_accepted += 1
-            end
-            length(raw_points) >= n_interior + n_near_surface && break
+        inside_mask = isinside(candidates, alg.triangle_octree)
+        target = n_interior + n_near_surface
+        for i in eachindex(candidates)
+            length(raw_points) >= target && break
+            inside_mask[i] && push!(raw_points, candidates[i])
         end
     end
+    n_accepted = length(raw_points) - length(interior_points)
     println(" done ($n_accepted accepted, $(round(t6, digits = 2))s)")
 
-    # Fill deficit. Must apply isinside here too — deficit samples are drawn from
-    # interior leaf bounding boxes, which (for the same aspect-ratio reason) can
-    # extend past the geometry. Retry-capped to avoid infinite loops when the
-    # selected leaf has very little interior overlap.
+    # Fill deficit from interior leaves. No isinside needed — interior leaves
+    # are guaranteed not to overlap any boundary triangle-octree leaf.
     if length(raw_points) < max_points
         deficit = max_points - length(raw_points)
         println("  Filling deficit of $deficit points...")
@@ -411,21 +394,10 @@ function _discretize_volume(
         total_weight = isempty(cumulative_weights) ? zero(T) : cumulative_weights[end]
 
         if total_weight > zero(T)
-            target = length(raw_points) + deficit
-            max_attempts = 10 * deficit
-            attempts = 0
-            while length(raw_points) < target && attempts < max_attempts
-                attempts += 1
+            for _ in 1:deficit
                 idx = clamp(searchsortedfirst(cumulative_weights, rand(T) * total_weight), 1, length(interior.indices))
                 bbox_min, bbox_max = box_bounds(node_tree, interior.indices[idx])
-                p = _rand_point_in_box(bbox_min, bbox_max)
-                if isinside(p, alg.triangle_octree)
-                    push!(raw_points, p)
-                end
-            end
-            remaining = target - length(raw_points)
-            if remaining > 0
-                @warn "Octree deficit fill gave up before reaching target" requested = deficit filled = (deficit - remaining) attempts = attempts
+                push!(raw_points, _rand_point_in_box(bbox_min, bbox_max))
             end
         end
     end

--- a/src/discretization/algorithms/octree.jl
+++ b/src/discretization/algorithms/octree.jl
@@ -360,10 +360,26 @@ function _discretize_volume(
     raw_points = SVector{3, T}[]
     sizehint!(raw_points, max_points)
 
-    print("  Generating interior points...")
-    t4 = @elapsed interior_points = _generate_from_leaves(interior, node_tree, n_interior, alg.placement)
-    println(" done ($(length(interior_points)) points, $(round(t4, digits = 2))s)")
-    append!(raw_points, interior_points)
+    # Interior candidates need the same isinside filter as near-surface:
+    # for high-aspect-ratio domains, cubic octree leaves classified as interior
+    # can extend beyond the actual geometry, so unchecked samples land outside.
+    n_interior_candidates = round(Int, n_interior * alg.boundary_oversampling)
+    print("  Generating interior candidates...")
+    t4 = @elapsed interior_candidates = _generate_from_leaves(interior, node_tree, n_interior_candidates, alg.placement)
+    println(" done ($(length(interior_candidates)) candidates, $(round(t4, digits = 2))s)")
+
+    print("  Filtering interior candidates (isinside check)...")
+    n_interior_accepted = 0
+    t4f = @elapsed begin
+        for p in interior_candidates
+            length(raw_points) >= n_interior && break
+            if isinside(p, alg.triangle_octree)
+                push!(raw_points, p)
+                n_interior_accepted += 1
+            end
+        end
+    end
+    println(" done ($n_interior_accepted accepted, $(round(t4f, digits = 2))s)")
 
     n_candidates = round(Int, n_near_surface * alg.boundary_oversampling)
     print("  Generating near-surface candidates...")
@@ -384,18 +400,32 @@ function _discretize_volume(
     end
     println(" done ($n_accepted accepted, $(round(t6, digits = 2))s)")
 
-    # Fill deficit if near-surface rejection left us short
+    # Fill deficit. Must apply isinside here too — deficit samples are drawn from
+    # interior leaf bounding boxes, which (for the same aspect-ratio reason) can
+    # extend past the geometry. Retry-capped to avoid infinite loops when the
+    # selected leaf has very little interior overlap.
     if length(raw_points) < max_points
         deficit = max_points - length(raw_points)
         println("  Filling deficit of $deficit points...")
         cumulative_weights = isempty(interior.weights) ? T[] : cumsum(interior.weights)
         total_weight = isempty(cumulative_weights) ? zero(T) : cumulative_weights[end]
 
-        for _ in 1:deficit
-            if total_weight > zero(T)
+        if total_weight > zero(T)
+            target = length(raw_points) + deficit
+            max_attempts = 10 * deficit
+            attempts = 0
+            while length(raw_points) < target && attempts < max_attempts
+                attempts += 1
                 idx = clamp(searchsortedfirst(cumulative_weights, rand(T) * total_weight), 1, length(interior.indices))
                 bbox_min, bbox_max = box_bounds(node_tree, interior.indices[idx])
-                push!(raw_points, _rand_point_in_box(bbox_min, bbox_max))
+                p = _rand_point_in_box(bbox_min, bbox_max)
+                if isinside(p, alg.triangle_octree)
+                    push!(raw_points, p)
+                end
+            end
+            remaining = target - length(raw_points)
+            if remaining > 0
+                @warn "Octree deficit fill gave up before reaching target" requested = deficit filled = (deficit - remaining) attempts = attempts
             end
         end
     end

--- a/src/octree/spacing_criterion.jl
+++ b/src/octree/spacing_criterion.jl
@@ -98,6 +98,15 @@ function build_node_octree(triangle_octree, spacing, alpha, node_min_ratio)
 end
 
 @inline function _mesh_geometry_query(pt::SVector{3, T}, tol, octree) where {T}
+    # Sign voting inside `_compute_signed_distance_octree` can flip for points
+    # far outside the triangle octree's cubic root, producing negative signed
+    # distances (and therefore LEAF_INTERIOR) above regions of space that are
+    # obviously exterior to the mesh. The mesh bbox is the authoritative
+    # envelope — anything strictly outside it (by more than the classification
+    # tolerance) is exterior, matching the fast-path used by `isinside`.
+    if any(pt .< octree.mesh_bbox_min .- tol) || any(pt .> octree.mesh_bbox_max .+ tol)
+        return LEAF_EXTERIOR
+    end
     sd = _compute_signed_distance_octree(pt, octree.mesh, octree.tree)
     return _leaf_class_from_signed_distance(sd, tol)
 end
@@ -155,16 +164,16 @@ end
 """
     classify_node_octree(node_tree, triangle_octree)
 
-Classify node octree leaves as interior, boundary, or exterior.
-
-Uses the triangle octree's geometry query to determine the classification
-of each leaf in the node octree.
+Classify node octree leaves as interior, boundary, or exterior using the
+triangle octree's geometry query. Correctness of downstream sampling
+(skipping `isinside` on `LEAF_INTERIOR` points) relies on the mesh-bbox
+early return inside `_mesh_geometry_query`, which prevents sign-vote flips
+from promoting far-exterior leaves into `LEAF_INTERIOR`.
 
 # Returns
-Dictionary mapping leaf indices to classification (`LEAF_INTERIOR`, `LEAF_BOUNDARY`, `LEAF_EXTERIOR`)
+Vector of `Int8` classifications indexed by node-octree box index.
 """
 function classify_node_octree(node_tree, triangle_octree)
-    # Reuse existing classification infrastructure from spatial_octree.jl
     query(pt, tol) = _mesh_geometry_query(pt, tol, triangle_octree)
     return classify_leaves!(node_tree, query)
 end

--- a/test/octree.jl
+++ b/test/octree.jl
@@ -48,6 +48,50 @@ end
     end
 end
 
+@testitem "Octree points are inside (high-aspect-ratio domain, #76)" setup = [CommonImports] begin
+    using Random
+    using Meshes: SimpleMesh, connect, Triangle, Point
+    Random.seed!(76)
+
+    # Regression test for #76: interior and deficit points were placed in
+    # node-octree leaf bounding boxes with no isinside filter, so for
+    # high-aspect-ratio domains the cubic leaves at the thin boundary
+    # produced points far outside the actual geometry.
+    vertices = Point.(
+        [
+            (0.0, 0.0, 0.0), (20.0, 0.0, 0.0), (20.0, 7.0, 0.0), (0.0, 7.0, 0.0),
+            (0.0, 0.0, 3.0), (20.0, 0.0, 3.0), (20.0, 7.0, 3.0), (0.0, 7.0, 3.0),
+        ]
+    )
+    triangles = [
+        connect((1, 3, 2), Triangle), connect((1, 4, 3), Triangle),
+        connect((5, 6, 7), Triangle), connect((5, 7, 8), Triangle),
+        connect((1, 2, 6), Triangle), connect((1, 6, 5), Triangle),
+        connect((3, 4, 8), Triangle), connect((3, 8, 7), Triangle),
+        connect((1, 5, 8), Triangle), connect((1, 8, 4), Triangle),
+        connect((2, 3, 7), Triangle), connect((2, 7, 6), Triangle),
+    ]
+    mesh = SimpleMesh(vertices, triangles)
+    bnd = PointBoundary(mesh)
+    spacing = ConstantSpacing(0.5m)
+
+    alg = Octree(mesh; spacing)
+    cloud = discretize(bnd, spacing; alg, max_points = 500)
+
+    # Every volume point must pass the geometry check, not just the
+    # near-surface candidates that happened to be filtered.
+    octree = alg.triangle_octree
+    for pt in WhatsThePoint.volume(cloud)
+        c = to(pt)
+        sv = SVector{3, Float64}(c[1] / m, c[2] / m, c[3] / m)
+        @test isinside(sv, octree) == true
+    end
+
+    # Deficit filling must actually close the deficit when the interior is
+    # reachable (a 20×7×3 box is well inside the octree resolution here).
+    @test length(WhatsThePoint.volume(cloud)) >= 450
+end
+
 @testitem "Octree with placement strategies" setup = [CommonImports, OctreeTestData] begin
     using Random
     Random.seed!(456)


### PR DESCRIPTION
## Summary

Fixes #76.

### Root cause

`_compute_signed_distance_octree`'s sign-vote logic can flip for points far outside the triangle octree's cubic root, producing a **negative** signed distance (and therefore `LEAF_INTERIOR`) above regions of space that are obviously exterior to the mesh. On the 20×7×3 reproducer, leaves at z ≥ 10 were classified `LEAF_INTERIOR` and seeded the volume point cloud with out-of-domain points.

`isinside` already dodges this with a mesh-bbox fast-path (`src/octree/triangle_octree.jl:451`), but `_mesh_geometry_query` — the classification hook — did not. Adding the same guard there makes `LEAF_INTERIOR` actually trustworthy, which lets the interior path and deficit fill drop the per-point `isinside` filter entirely.

### Changes

- **`src/octree/spacing_criterion.jl`** — `_mesh_geometry_query` returns `LEAF_EXTERIOR` for points outside the mesh bbox (tolerance-aware), matching the `isinside` fast-path. Docs for `classify_node_octree` updated to state the invariant.
- **`src/discretization/algorithms/octree.jl`**:
  - Interior path: generate exactly `n_interior` points from `LEAF_INTERIOR` leaves. No oversampling, no `isinside`.
  - Deficit fill: sample from `LEAF_INTERIOR` leaves. No filter, no retry cap.
  - Near-surface filter: switched to the vectorized `isinside(::Vector, ::TriangleOctree)` (tmap-parallel) instead of a serial loop.
- **`test/octree.jl`** — regression test `@testitem "Octree points are inside (high-aspect-ratio domain, #76)"` using the 20×7×3 reproducer.

### Perf impact vs main@HEAD

- Interior path is back to O(N_int) RNG — same as before the bug existed.
- Deficit fill is back to O(D) sampling — same as before.
- Near-surface filter is faster (tmap across all cores) than the previous serial loop.
- Net effect: correctness restored **with no per-point-isinside overhead** on the interior path.

### Verification

- `julia --project -e 'using Pkg; Pkg.test()'` — all tests pass, 2 pre-existing broken unchanged.
- `runic --check` clean.

### History note

First commit (`a6ac47d`) added per-point `isinside` filters on all paths. Second commit (`01834dc`) pivots to the root-cause fix described above and removes the per-point overhead. Squash at merge time for a single clean entry.