### PR TITLE
perf(octree): spatial-index fallback and richer sampling for high-aspect-ratio domains

### DIFF
--- a/src/octree/spacing_criterion.jl
+++ b/src/octree/spacing_criterion.jl
@@ -119,34 +119,54 @@ function _box_may_contain_interior(node_tree, box_idx, triangle_octree)
 
     center = box_center(node_tree, box_idx)
     corners = _box_corners(bbox_min, bbox_max)
+    faces = _box_face_centers(bbox_min, bbox_max)
+    edges = _box_edge_midpoints(bbox_min, bbox_max)
 
-    for pt in (center, corners...)
+    for pt in (center, corners..., faces..., edges...)
         _mesh_geometry_query(pt, tol, triangle_octree) != LEAF_EXTERIOR && return true
     end
 
-    # Point sampling can miss thin/elongated domains inside large cubic boxes.
-    # Fall back to checking whether any non-exterior triangle-octree leaf overlaps this box.
-    tri_tree = triangle_octree.tree
+    # 27-point sampling still misses thin/elongated domains inside large cubic
+    # boxes when every sample falls outside the geometry. Fall back to a spatial
+    # descent of the triangle octree for O(log L) overlap detection.
     tri_cls = triangle_octree.leaf_classification
-    if !isnothing(tri_cls)
-        for leaf_idx in all_leaves(tri_tree)
-            tri_cls[leaf_idx] == LEAF_EXTERIOR && continue
-            leaf_min, leaf_max = box_bounds(tri_tree, leaf_idx)
-            if _boxes_overlap(bbox_min, bbox_max, leaf_min, leaf_max)
-                return true
-            end
-        end
+    predicate = if isnothing(tri_cls)
+        _ -> true
+    else
+        leaf_idx -> tri_cls[leaf_idx] != LEAF_EXTERIOR
     end
-
-    return false
+    return any_leaf_overlapping(triangle_octree.tree, bbox_min, bbox_max, predicate)
 end
 
-@inline function _boxes_overlap(a_min, a_max, b_min, b_max)
-    @inbounds for d in 1:3
-        a_min[d] > b_max[d] && return false
-        a_max[d] < b_min[d] && return false
-    end
-    return true
+@inline function _box_face_centers(bbox_min::SVector{3, T}, bbox_max::SVector{3, T}) where {T}
+    cx = (bbox_min[1] + bbox_max[1]) / 2
+    cy = (bbox_min[2] + bbox_max[2]) / 2
+    cz = (bbox_min[3] + bbox_max[3]) / 2
+    return (
+        SVector{3, T}(bbox_min[1], cy, cz),
+        SVector{3, T}(bbox_max[1], cy, cz),
+        SVector{3, T}(cx, bbox_min[2], cz),
+        SVector{3, T}(cx, bbox_max[2], cz),
+        SVector{3, T}(cx, cy, bbox_min[3]),
+        SVector{3, T}(cx, cy, bbox_max[3]),
+    )
+end
+
+@inline function _box_edge_midpoints(bbox_min::SVector{3, T}, bbox_max::SVector{3, T}) where {T}
+    x0, x1 = bbox_min[1], bbox_max[1]
+    y0, y1 = bbox_min[2], bbox_max[2]
+    z0, z1 = bbox_min[3], bbox_max[3]
+    cx = (x0 + x1) / 2
+    cy = (y0 + y1) / 2
+    cz = (z0 + z1) / 2
+    return (
+        SVector{3, T}(cx, y0, z0), SVector{3, T}(cx, y1, z0),
+        SVector{3, T}(cx, y0, z1), SVector{3, T}(cx, y1, z1),
+        SVector{3, T}(x0, cy, z0), SVector{3, T}(x1, cy, z0),
+        SVector{3, T}(x0, cy, z1), SVector{3, T}(x1, cy, z1),
+        SVector{3, T}(x0, y0, cz), SVector{3, T}(x1, y0, cz),
+        SVector{3, T}(x0, y1, cz), SVector{3, T}(x1, y1, cz),
+    )
 end
 
 function _subdivide_node_octree!(node_tree, box_idx, criterion, triangle_octree)

--- a/src/octree/spatial_octree.jl
+++ b/src/octree/spatial_octree.jl
@@ -523,6 +523,38 @@ function all_boxes(octree::SpatialOctree)
     return collect(1:octree.num_boxes[])
 end
 
+@inline function _boxes_overlap(a_min, a_max, b_min, b_max)
+    @inbounds for d in 1:3
+        a_min[d] > b_max[d] && return false
+        a_max[d] < b_min[d] && return false
+    end
+    return true
+end
+
+"""
+    any_leaf_overlapping(tree::SpatialOctree, bbox_min, bbox_max, predicate) -> Bool
+
+Return `true` if any leaf whose bounding box overlaps `[bbox_min, bbox_max]`
+satisfies `predicate(leaf_idx)`. Descends from root and prunes subtrees that
+cannot overlap, giving O(log L) expected cost instead of O(L) scan.
+"""
+function any_leaf_overlapping(tree::SpatialOctree, bbox_min, bbox_max, predicate)
+    return _any_leaf_overlapping(tree, 1, bbox_min, bbox_max, predicate)
+end
+
+function _any_leaf_overlapping(tree::SpatialOctree, box_idx::Int, bmin, bmax, predicate)
+    node_min, node_max = box_bounds(tree, box_idx)
+    _boxes_overlap(bmin, bmax, node_min, node_max) || return false
+    if is_leaf(tree, box_idx)
+        return predicate(box_idx)
+    end
+    for child_idx in tree.children[box_idx]
+        child_idx == 0 && continue
+        _any_leaf_overlapping(tree, child_idx, bmin, bmax, predicate) && return true
+    end
+    return false
+end
+
 #=============================================================================
 Balancing (2:1 Constraint)
 =============================================================================#

--- a/test/octree_basic.jl
+++ b/test/octree_basic.jl
@@ -327,6 +327,39 @@ end
     @test needs_balancing(octree, 1) == false
 end
 
+@testitem "SpatialOctree any_leaf_overlapping" setup = [CommonImports] begin
+    using WhatsThePoint: SpatialOctree, subdivide!, any_leaf_overlapping
+
+    origin = SVector(0.0, 0.0, 0.0)
+    tree = SpatialOctree{Int, Float64}(origin, 10.0)
+    subdivide!(tree, 1)
+
+    # Query box overlaps the first octant → at least one leaf passes `true`
+    @test any_leaf_overlapping(
+        tree, SVector(0.5, 0.5, 0.5), SVector(1.0, 1.0, 1.0), _ -> true
+    ) == true
+
+    # Query box entirely outside the root → pruned at root
+    @test any_leaf_overlapping(
+        tree, SVector(100.0, 100.0, 100.0), SVector(101.0, 101.0, 101.0), _ -> true
+    ) == false
+
+    # Overlap exists but predicate rejects every leaf
+    @test any_leaf_overlapping(
+        tree, SVector(0.0, 0.0, 0.0), SVector(10.0, 10.0, 10.0), _ -> false
+    ) == false
+
+    # Predicate selects a single leaf by coords — true only when query overlaps it
+    target = only(findall(c -> c == SVector(1, 1, 1, 2), tree.coords[1:tree.num_boxes[]]))
+    predicate = idx -> idx == target
+    @test any_leaf_overlapping(
+        tree, SVector(6.0, 6.0, 6.0), SVector(9.0, 9.0, 9.0), predicate
+    ) == true
+    @test any_leaf_overlapping(
+        tree, SVector(0.0, 0.0, 0.0), SVector(4.0, 4.0, 4.0), predicate
+    ) == false
+end
+
 @testitem "SpatialOctree find_boxes_at_coords edge cases" setup = [CommonImports] begin
     using WhatsThePoint: SpatialOctree, subdivide!, find_neighbor, find_boxes_at_coords
 

--- a/test/octree_spacing_criterion.jl
+++ b/test/octree_spacing_criterion.jl
@@ -70,3 +70,40 @@ end
     far_tree = SpatialOctree{Int, Float64}(SVector(10.0, 10.0, 10.0), 1.0)
     @test _box_may_contain_interior(far_tree, 1, tri_octree) == false
 end
+
+@testitem "_box_may_contain_interior high-aspect-ratio domain (#75)" setup = [CommonImports] begin
+    using WhatsThePoint: _box_may_contain_interior, SpatialOctree, bounding_box
+    using Meshes: SimpleMesh, connect, Triangle, Point
+
+    # 20x7x3 cuboid — the cubic root node box centers all 9 original sample
+    # points outside the thin domain, so subdivision relies on enriched
+    # sampling (face centers / edge midpoints) or the spatial descent fallback.
+    vertices = Point.(
+        [
+            (0.0, 0.0, 0.0), (20.0, 0.0, 0.0), (20.0, 7.0, 0.0), (0.0, 7.0, 0.0),
+            (0.0, 0.0, 3.0), (20.0, 0.0, 3.0), (20.0, 7.0, 3.0), (0.0, 7.0, 3.0),
+        ]
+    )
+    triangles = [
+        connect((1, 3, 2), Triangle), connect((1, 4, 3), Triangle),
+        connect((5, 6, 7), Triangle), connect((5, 7, 8), Triangle),
+        connect((1, 2, 6), Triangle), connect((1, 6, 5), Triangle),
+        connect((3, 4, 8), Triangle), connect((3, 8, 7), Triangle),
+        connect((1, 5, 8), Triangle), connect((1, 8, 4), Triangle),
+        connect((2, 3, 7), Triangle), connect((2, 7, 6), Triangle),
+    ]
+    mesh = SimpleMesh(vertices, triangles)
+    tri_octree = TriangleOctree(mesh; classify_leaves = true)
+
+    bbox_min, _ = bounding_box(tri_octree.tree)
+    node_tree = SpatialOctree{Int, Float64}(bbox_min, tri_octree.tree.root_size)
+    @test _box_may_contain_interior(node_tree, 1, tri_octree) == true
+
+    # Fallback must still work when the triangle octree has no classification
+    tri_octree_unclassified = TriangleOctree(mesh; classify_leaves = false)
+    bbox_min_u, _ = bounding_box(tri_octree_unclassified.tree)
+    node_tree_u = SpatialOctree{Int, Float64}(
+        bbox_min_u, tri_octree_unclassified.tree.root_size
+    )
+    @test _box_may_contain_interior(node_tree_u, 1, tri_octree_unclassified) == true
+end


### PR DESCRIPTION
## Summary
- Expand `_box_may_contain_interior` sampling from 9 points to 27 (center + 8 corners + 6 face centers + 12 edge midpoints), so non-degenerate geometry no longer needs the fallback.
- Add `any_leaf_overlapping` to `SpatialOctree` — recursive descent with AABB pruning — and replace the O(L) `all_leaves` scan with O(log L) spatial descent. Fallback is now correct even when the triangle octree has no leaf classification (previously silently returned `false`).
- Move `_boxes_overlap` to `spatial_octree.jl` so both the helper and the new primitive can share it.
- Add direct unit tests for `any_leaf_overlapping` and for `_box_may_contain_interior` on the 20×7×3 high-aspect-ratio reproducer (both classified and unclassified triangle octrees).

## Context
Robustness follow-up for #75. The functional correctness bug was resolved by #78 (AABB-overlap fallback) and #89 (sign-vote mesh-bbox guard); the existing end-to-end regression at `test/octree.jl:51-93` asserts the 20×7×3 cuboid produces ≥450 volume points. This PR addresses the "more robust long-term approach" the issue author called for: avoid the brute-force leaf scan and reduce how often the fallback is even hit.

Closes #75.