### PR TITLE
feat(metrics): spacing_metrics to validate spacing preservation

### DIFF
--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -105,6 +105,7 @@ repel
 
 ```@docs
 metrics
+spacing_metrics
 ```
 
 ## I/O

--- a/src/WhatsThePoint.jl
+++ b/src/WhatsThePoint.jl
@@ -31,7 +31,7 @@ const spinner_icons = "⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏"
 const Angle{T} = Union{Quantity{T, NoDims, typeof(u"rad")}, Quantity{T, NoDims, typeof(u"°")}}
 
 include("utils.jl")
-export metrics
+export metrics, spacing_metrics
 
 include("geometry.jl")
 

--- a/src/metrics.jl
+++ b/src/metrics.jl
@@ -22,3 +22,33 @@ function metrics(cloud::PointCloud; k = 20)
     println("min. distance to $k nearest neighbors: $mn")
     return (; avg, std = σ, max = mx, min = mn, k)
 end
+
+"""
+    spacing_metrics(cloud::PointCloud, spacing::AbstractSpacing; k=20)
+
+Measure how closely the point distribution matches the target `spacing` function.
+
+For each point `xᵢ`, the local actual spacing is estimated as the mean distance to
+its `k` nearest neighbors (self excluded). The per-point relative error is
+
+    errorᵢ = |r̄ᵢ − s(xᵢ)| / s(xᵢ)
+
+Returns a `NamedTuple` `(max_error, mean_error, std_error, k)`. Use before and after
+`repel` (or any placement step) to quantify spacing preservation.
+"""
+function spacing_metrics(cloud::PointCloud, spacing::AbstractSpacing; k = 20)
+    pts = points(cloud)
+    method = KNearestSearch(cloud, k)
+    results = searchdists(cloud, method)
+
+    target = ustrip.(spacing.(pts))
+    actual = map(r -> mean(ustrip.(@view r[2][2:end])), results)
+    errors = @. abs(actual - target) / target
+
+    return (;
+        max_error = maximum(errors),
+        mean_error = mean(errors),
+        std_error = std(errors),
+        k,
+    )
+end

--- a/test/metrics.jl
+++ b/test/metrics.jl
@@ -141,3 +141,74 @@ end
     @test result2 isa NamedTuple
     @test result2.k == 20
 end
+
+@testitem "spacing_metrics return shape" setup = [TestData, CommonImports] begin
+    boundary = PointBoundary(TestData.BOX_PATH)
+    octree = TriangleOctree(TestData.BOX_PATH; classify_leaves = true)
+    spacing = _relative_spacing(boundary)
+    cloud = discretize(boundary, spacing; alg = SlakKosec(octree), max_points = 50)
+
+    result = spacing_metrics(cloud, spacing)
+
+    @test result isa NamedTuple
+    @test haskey(result, :max_error)
+    @test haskey(result, :mean_error)
+    @test haskey(result, :std_error)
+    @test haskey(result, :k)
+    @test result.k == 20
+    @test isfinite(result.max_error)
+    @test isfinite(result.mean_error)
+    @test isfinite(result.std_error)
+    @test result.max_error >= result.mean_error
+    @test result.mean_error >= 0
+end
+
+@testitem "spacing_metrics custom k" setup = [TestData, CommonImports] begin
+    boundary = PointBoundary(TestData.BOX_PATH)
+    octree = TriangleOctree(TestData.BOX_PATH; classify_leaves = true)
+    spacing = _relative_spacing(boundary)
+    cloud = discretize(boundary, spacing; alg = SlakKosec(octree), max_points = 50)
+
+    for k in (5, 10, 20)
+        result = spacing_metrics(cloud, spacing; k = k)
+        @test result.k == k
+        @test isfinite(result.mean_error)
+    end
+end
+
+@testitem "spacing_metrics penalizes mismatched target" setup = [TestData, CommonImports] begin
+    using Unitful: m
+
+    boundary = PointBoundary(TestData.BOX_PATH)
+    octree = TriangleOctree(TestData.BOX_PATH; classify_leaves = true)
+    spacing_correct = _relative_spacing(boundary)
+    cloud = discretize(boundary, spacing_correct; alg = SlakKosec(octree), max_points = 50)
+
+    spacing_too_large = ConstantSpacing(100 * spacing_correct.Δx)
+    spacing_too_small = ConstantSpacing(spacing_correct.Δx / 100)
+
+    err_good = spacing_metrics(cloud, spacing_correct)
+    err_large = spacing_metrics(cloud, spacing_too_large)
+    err_small = spacing_metrics(cloud, spacing_too_small)
+
+    @test err_large.mean_error > err_good.mean_error
+    @test err_small.mean_error > err_good.mean_error
+end
+
+@testitem "spacing_metrics tracks repel" setup = [TestData, CommonImports] begin
+    boundary = PointBoundary(TestData.BOX_PATH)
+    octree = TriangleOctree(TestData.BOX_PATH; classify_leaves = true)
+    spacing = _relative_spacing(boundary)
+    cloud = discretize(boundary, spacing; alg = SlakKosec(octree), max_points = 50)
+
+    pre = spacing_metrics(cloud, spacing)
+
+    new_cloud = repel(cloud, spacing, octree; max_iters = 20)
+    post = spacing_metrics(new_cloud, spacing)
+
+    @test isfinite(pre.mean_error)
+    @test isfinite(post.mean_error)
+    # Sanity only — exact preservation is future work. Confirms repel doesn't
+    # catastrophically destroy the spacing relationship.
+    @test post.mean_error < 10 * pre.mean_error + 1
+end


### PR DESCRIPTION
## Summary

Closes #81.

- Adds public `spacing_metrics(cloud, spacing; k=20)` in `src/metrics.jl`, returning `(max_error, mean_error, std_error, k)`. Per-point error is `|r̄_i − s(x_i)| / s(x_i)`, where `r̄_i` is the mean distance to the `k` nearest neighbors (self excluded).
- Exports `spacing_metrics` alongside existing `metrics`.
- Adds 4 `@testitem` blocks: return shape, custom `k`, mismatch penalty (correct vs 100× too large / too small), and a repel integration sanity check.
- `repel()` intentionally unchanged — the original issue proposed a collector kwarg + `@warn` inside `repel`; we decoupled and exposed a standalone metric the caller can invoke before/after any placement step.