### PR TITLE
feat(repel): pluggable force models with spacing equilibrium

### DIFF
--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -99,6 +99,10 @@ Point distribution optimization.
 
 ```@docs
 repel
+RepelForceModel
+InverseDistanceForce
+SpacingEquilibriumForce
+compute_force
 ```
 
 ## Diagnostics

--- a/docs/src/repel.md
+++ b/docs/src/repel.md
@@ -42,11 +42,47 @@ cloud = repel(cloud, spacing; β=0.2, max_iters=1000, convergence=conv)
 
 | Parameter | Default | Description |
 |-----------|---------|-------------|
-| `β` | `0.2` | Repulsion strength — controls force magnitude |
+| `force_model` | `InverseDistanceForce(β)` | Force law, any [`RepelForceModel`](@ref) subtype |
+| `β` | `0.2` | Repulsion softening — feeds the default `force_model` |
 | `α` | `0.05 × min(spacing)` | Step size — distance points move per iteration |
 | `k` | `21` | Number of nearest neighbors used in repulsion stencil |
 | `max_iters` | `1000` | Maximum number of repulsion iterations |
 | `tol` | `1e-6` | Convergence tolerance on relative point movement |
+
+## Force Models
+
+The force law is abstracted through [`RepelForceModel`](@ref) so users can choose
+how points interact. All models take a single softening parameter `β` and
+implement `compute_force(model, u)` where `u = r / s` is the ratio of neighbor
+distance to local target spacing.
+
+### [`InverseDistanceForce`](@ref) — default
+
+```math
+F(u) = \frac{1}{(u^2 + \beta)^2}
+```
+
+Purely repulsive and monotonically decreasing. This is the original Miotti
+(2023) formulation. The force has no root, so equilibrium is reached only
+through damping via `α` — the point configuration never stops moving on its
+own, which is why a `tol` threshold is needed.
+
+### [`SpacingEquilibriumForce`](@ref)
+
+```math
+F(u) = \frac{1 - u^2}{(u^2 + \beta)^2}
+```
+
+Zero at `u = 1` (neighbor exactly at the target spacing), positive for `u < 1`
+(push apart), negative for `u > 1` (pull together). Useful when the
+discretization is locally too sparse and you want repulsion to fill gaps as
+well as push crowded points apart.
+
+```julia
+cloud = repel(cloud, spacing, octree;
+              force_model = SpacingEquilibriumForce(0.2),
+              max_iters = 500)
+```
 
 ## Tuning Guide
 
@@ -60,13 +96,9 @@ cloud = repel(cloud, spacing; β=0.2, max_iters=1000, convergence=conv)
 Each iteration:
 
 1. Build a k-nearest neighbor tree of all points
-2. For each point, compute a repulsive force from its k neighbors using
-
-```math
-F(r) = \frac{1}{(r^2 + \beta)^2}
-```
-
-where `r` is the distance to a neighbor. The `β` parameter prevents singularity at `r = 0` and controls the force shape.
+2. For each point, compute a force from its `k` neighbors using the chosen
+   [`RepelForceModel`](@ref). See [Force Models](#Force-Models) above for the
+   available laws.
 
 3. Move each point by `α` in the direction of the net repulsive force
 4. Constrain points to the domain:

--- a/src/WhatsThePoint.jl
+++ b/src/WhatsThePoint.jl
@@ -84,6 +84,9 @@ include("discretization/discretization.jl")
 export AbstractNodeGenerationAlgorithm, SlakKosec, VanDerSandeFornberg, FornbergFlyer, Octree
 export discretize
 
+include("repel_forces.jl")
+export RepelForceModel, InverseDistanceForce, SpacingEquilibriumForce, compute_force
+
 include("repel.jl")
 export repel
 

--- a/src/repel.jl
+++ b/src/repel.jl
@@ -1,5 +1,7 @@
 """
-    repel(cloud::PointCloud, spacing; β=0.2, α=auto, k=21, max_iters=1000, tol=1e-6, convergence=nothing)
+    repel(cloud::PointCloud, spacing;
+          force_model=InverseDistanceForce(β), β=0.2,
+          α=auto, k=21, max_iters=1000, tol=1e-6, convergence=nothing)
 
 Optimize point distribution via node repulsion (Miotti 2023).
 Only volume points move; escaped points are discarded via `isinside` filtering.
@@ -7,11 +9,19 @@ Only volume points move; escaped points are discarded via `isinside` filtering.
 The returned cloud has `NoTopology` since points have moved.
 
 Pass a `Vector{Float64}` via the `convergence` keyword to collect the convergence history.
+
+The force law is controlled by `force_model`, any subtype of [`RepelForceModel`](@ref).
+The default [`InverseDistanceForce`](@ref) reproduces the original Miotti (2023) behavior.
+Use [`SpacingEquilibriumForce`](@ref) for a force that vanishes at `r = s` (target
+spacing) rather than relying on damping alone to stop movement. `β` is kept as a
+convenience kwarg that feeds the default `InverseDistanceForce`; it is ignored when
+`force_model` is passed explicitly.
 """
 function repel(
         cloud::PointCloud{𝔼{N}, C},
         spacing;
         β = 0.2,
+        force_model::RepelForceModel = InverseDistanceForce(β),
         α = minimum(spacing.(to(cloud))) * 0.05,
         k = 21,
         max_iters = 1000,
@@ -32,9 +42,6 @@ function repel(
 
     conv = Float64[]
     i = 1
-    F = let β = β
-        r -> 1 / (r^2 + β)^2
-    end
     while i <= max_iters
         p_old .= p
         tmap!(p, 1:npoints) do id
@@ -47,7 +54,7 @@ function repel(
 
             repel_force = sum(zip(neighborhood, rij)) do z
                 xj, r = z
-                @inbounds F(r / s) * (xi - xj) / r
+                @inbounds compute_force(force_model, r / s) * (xi - xj) / r
             end
 
             return xi + Vec(s * α * repel_force)
@@ -70,7 +77,9 @@ function repel(
 end
 
 """
-    repel(cloud::PointCloud, spacing, octree::TriangleOctree; β=0.2, α=auto, k=21, max_iters=1000, tol=1e-6, convergence=nothing)
+    repel(cloud::PointCloud, spacing, octree::TriangleOctree;
+          force_model=InverseDistanceForce(β), β=0.2,
+          α=auto, k=21, max_iters=1000, tol=1e-6, convergence=nothing)
 
 Optimize point distribution via node repulsion (Miotti 2023) with boundary projection.
 
@@ -83,12 +92,16 @@ single unified surface named `:boundary`. Use `split_surface!(cloud.boundary, an
 re-establish surface distinctions if needed.
 
 Pass a `Vector{Float64}` via the `convergence` keyword to collect the convergence history.
+
+`force_model` accepts any subtype of [`RepelForceModel`](@ref); see the method without
+`octree` for details on the available force laws.
 """
 function repel(
         cloud::PointCloud{𝔼{3}, C},
         spacing,
         octree::TriangleOctree;
         β = 0.2,
+        force_model::RepelForceModel = InverseDistanceForce(β),
         α = minimum(spacing.(to(cloud))) * 0.05,
         k = 21,
         max_iters = 1000,
@@ -118,9 +131,6 @@ function repel(
     tri_indices = zeros(Int, npoints_total)
 
     conv = Float64[]
-    F = let β = β
-        r -> 1 / (r^2 + β)^2
-    end
     i = 1
     while i <= max_iters
         p_old .= p
@@ -134,7 +144,7 @@ function repel(
 
             repel_force = sum(zip(neighborhood, rij)) do z
                 xj, r = z
-                @inbounds F(r / s) * (xi - xj) / r
+                @inbounds compute_force(force_model, r / s) * (xi - xj) / r
             end
 
             x_proposed = xi + Vec(s * α * repel_force)

--- a/src/repel_forces.jl
+++ b/src/repel_forces.jl
@@ -1,0 +1,53 @@
+"""
+    RepelForceModel
+
+Abstract type for node-repulsion force laws used by [`repel`](@ref).
+
+A concrete subtype `M <: RepelForceModel` must implement
+
+    compute_force(m::M, u::Real) -> Real
+
+where `u = r / s` is the ratio of inter-point distance to local target spacing.
+The returned scalar multiplies the unit vector `(xᵢ − xⱼ) / r` in the repulsion
+step, so positive values push `xᵢ` away from `xⱼ` and negative values pull it
+toward `xⱼ`.
+"""
+abstract type RepelForceModel end
+
+"""
+    InverseDistanceForce(β=0.2)
+
+Original Miotti (2023) force law `F(u) = 1 / (u² + β)²`. Purely repulsive and
+monotonically decreasing. `β > 0` softens the force near `u = 0` and keeps it
+finite. Has no root, so equilibrium is reached only through damping (`α`).
+"""
+struct InverseDistanceForce{T <: Real} <: RepelForceModel
+    β::T
+end
+
+InverseDistanceForce() = InverseDistanceForce(0.2)
+
+@inline compute_force(m::InverseDistanceForce, u::Real) = inv((u * u + m.β)^2)
+
+"""
+    SpacingEquilibriumForce(β=0.2)
+
+Force law `F(u) = (1 − u²) / (u² + β)²` with a zero at `u = 1`. Repulsive for
+`u < 1` (points closer than the target spacing push apart), attractive for
+`u > 1` (points farther than the target pull together), and zero at the target
+spacing itself. `β > 0` softens the amplitude near `u = 0`.
+
+Shares the `β`-softened denominator with [`InverseDistanceForce`](@ref); the
+numerator `(1 − u²)` introduces the equilibrium at `u = 1` without changing
+the small-`u` behavior.
+"""
+struct SpacingEquilibriumForce{T <: Real} <: RepelForceModel
+    β::T
+end
+
+SpacingEquilibriumForce() = SpacingEquilibriumForce(0.2)
+
+@inline function compute_force(m::SpacingEquilibriumForce, u::Real)
+    u² = u * u
+    return (1 - u²) / (u² + m.β)^2
+end

--- a/src/repel_forces.jl
+++ b/src/repel_forces.jl
@@ -4,15 +4,22 @@
 Abstract type for node-repulsion force laws used by [`repel`](@ref).
 
 A concrete subtype `M <: RepelForceModel` must implement
-
-    compute_force(m::M, u::Real) -> Real
-
-where `u = r / s` is the ratio of inter-point distance to local target spacing.
-The returned scalar multiplies the unit vector `(xᵢ − xⱼ) / r` in the repulsion
-step, so positive values push `xᵢ` away from `xⱼ` and negative values pull it
-toward `xⱼ`.
+[`compute_force(m::M, u::Real)`](@ref compute_force).
 """
 abstract type RepelForceModel end
+
+"""
+    compute_force(model::RepelForceModel, u::Real) -> Real
+
+Evaluate the force magnitude at normalized separation `u = r / s`, where `r` is
+the distance between two points and `s` is the local target spacing.
+
+The returned scalar multiplies the unit vector `(xᵢ − xⱼ) / r` in the repulsion
+step, so positive values push `xᵢ` away from `xⱼ` and negative values pull it
+toward `xⱼ`. Concrete subtypes of [`RepelForceModel`](@ref) must implement a
+method for this function.
+"""
+function compute_force end
 
 """
     InverseDistanceForce(β=0.2)

--- a/test/repel.jl
+++ b/test/repel.jl
@@ -113,3 +113,99 @@ end
     @test conv isa Vector{<:AbstractFloat}
     @test length(conv) <= 3
 end
+
+@testitem "force model compute_force values" setup = [CommonImports] begin
+    # InverseDistanceForce reproduces F(u) = 1/(u²+β)² exactly
+    m1 = InverseDistanceForce(0.2)
+    for u in (0.0, 0.5, 1.0, 2.0)
+        expected = 1 / (u^2 + 0.2)^2
+        @test compute_force(m1, u) ≈ expected
+    end
+
+    # SpacingEquilibriumForce has zero at u=1, positive for u<1, negative for u>1
+    m2 = SpacingEquilibriumForce(0.2)
+    @test compute_force(m2, 1.0) == 0.0
+    @test compute_force(m2, 0.5) > 0
+    @test compute_force(m2, 2.0) < 0
+
+    # Default β matches the original repel default (0.2)
+    @test InverseDistanceForce().β == 0.2
+    @test SpacingEquilibriumForce().β == 0.2
+end
+
+@testitem "repel β kwarg feeds default force_model" setup = [TestData, CommonImports] begin
+    # The β kwarg must continue to affect the default InverseDistanceForce so that
+    # existing callers that pass `β=...` keep working without passing force_model.
+    boundary = PointBoundary(TestData.BOX_PATH)
+    octree = TriangleOctree(TestData.BOX_PATH; classify_leaves = true)
+    spacing = _relative_spacing(boundary)
+    cloud = discretize(boundary, spacing; alg = SlakKosec(octree), max_points = 30)
+
+    Random.seed!(1)
+    c_beta = repel(cloud, spacing, octree; β = 0.5, max_iters = 5)
+
+    Random.seed!(1)
+    c_model = repel(
+        cloud, spacing, octree;
+        force_model = InverseDistanceForce(0.5), max_iters = 5,
+    )
+
+    pts_beta = points(c_beta)
+    pts_model = points(c_model)
+    @test length(pts_beta) == length(pts_model)
+    for (a, b) in zip(pts_beta, pts_model)
+        @test a ≈ b
+    end
+end
+
+@testitem "repel accepts SpacingEquilibriumForce" setup = [TestData, CommonImports] begin
+    boundary = PointBoundary(TestData.BOX_PATH)
+    octree = TriangleOctree(TestData.BOX_PATH; classify_leaves = true)
+    spacing = _relative_spacing(boundary)
+    cloud = discretize(boundary, spacing; alg = SlakKosec(octree), max_points = 50)
+
+    original_total = length(cloud)
+
+    conv = Float64[]
+    new_cloud = repel(
+        cloud, spacing, octree;
+        force_model = SpacingEquilibriumForce(0.2),
+        max_iters = 20, convergence = conv,
+    )
+
+    @test length(new_cloud) == original_total
+    @test length(volume(new_cloud)) > 0
+    @test all(isfinite, conv)
+    for p in volume(new_cloud).points
+        @test isinside(p, octree)
+    end
+end
+
+@testitem "repel force models both reduce spacing error" setup = [TestData, CommonImports] begin
+    using WhatsThePoint: spacing_metrics
+
+    boundary = PointBoundary(TestData.BOX_PATH)
+    octree = TriangleOctree(TestData.BOX_PATH; classify_leaves = true)
+    spacing = _relative_spacing(boundary; divisor = 4)
+    cloud = discretize(boundary, spacing; alg = SlakKosec(octree), max_points = 80)
+
+    before = spacing_metrics(cloud, spacing; k = 10)
+
+    c_inv = repel(
+        cloud, spacing, octree;
+        force_model = InverseDistanceForce(0.2), max_iters = 40,
+    )
+    c_eq = repel(
+        cloud, spacing, octree;
+        force_model = SpacingEquilibriumForce(0.2), max_iters = 40,
+    )
+
+    after_inv = spacing_metrics(c_inv, spacing; k = 10)
+    after_eq = spacing_metrics(c_eq, spacing; k = 10)
+
+    # Both force models should leave the cloud at least as well-spaced as the
+    # initial discretization. This is a weak invariant — stronger claims about
+    # which model wins depend on α/β tuning and iteration count.
+    @test after_inv.mean_error <= before.mean_error * 1.1
+    @test after_eq.mean_error <= before.mean_error * 1.1
+end


### PR DESCRIPTION
## Summary

- Adds `RepelForceModel` abstraction with two concrete force laws for `repel`
- `InverseDistanceForce` (default) preserves current Miotti (2023) behavior: `F(u) = 1/(u²+β)²`
- `SpacingEquilibriumForce` adds an equilibrium at `u = r/s = 1`: `F(u) = (1-u²)/(u²+β)²`

Motivation (from #82): the original force law has no root, so point configurations never reach mechanical equilibrium — only damping via `α` brings them to rest. `SpacingEquilibriumForce` zeroes out when a neighbor sits at the target spacing, so interior points that are already well placed don't keep drifting.

## Change surface

- `src/repel_forces.jl` (new) — abstract type + two concrete models + `compute_force` interface
- `src/repel.jl` — threads `force_model::RepelForceModel` kwarg through both methods; removes the inlined `F` closures
- `src/WhatsThePoint.jl` — include + exports
- `test/repel.jl` — four new `@testitem` blocks covering force-value correctness, `β`-kwarg back-compat, `SpacingEquilibriumForce` end-to-end, and a spacing-error invariant using `spacing_metrics`
- `docs/src/repel.md`, `docs/src/api.md` — document the new kwarg and models

## Backward compatibility

The existing `β` kwarg is preserved and feeds the default `InverseDistanceForce(β)`. Existing callers passing `β = 0.3` (or omitting it entirely) produce identical point trajectories — this is asserted by a new test that compares `β = 0.5` against `force_model = InverseDistanceForce(0.5)` under a fixed RNG seed.

Closes #82.