### PR TITLE
chore(ci): restrict to linux only

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -40,8 +40,6 @@ jobs:
                     - "1.12"
                 os:
                     - ubuntu-latest
-                    - macos-latest
-                    - windows-latest
                 julia-arch:
                     - x64
                 julia-threads:


### PR DESCRIPTION
Drops macos-latest and windows-latest from the CI test matrix. Thread matrix and Julia versions (1.10/1.11/1.12) are unchanged.