### PR TITLE
refactor(types): thread CRS mactype end-to-end

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -275,6 +275,7 @@ test/
 ├── topology.jl                  # Topology tests (KNNTopology, RadiusTopology)
 ├── isinside.jl                  # Point-in-volume tests
 ├── discretization.jl            # Discretization algorithm tests
+├── float32_pipeline.jl          # End-to-end Float32 machine-type preservation tests
 ├── spacing_guidance.jl          # suggest_spacing and coarse-spacing clamp tests
 ├── surface_sampling.jl          # Poisson-disk surface sampling tests
 ├── repel.jl                     # Node repulsion tests

--- a/src/discretization/algorithms/octree.jl
+++ b/src/discretization/algorithms/octree.jl
@@ -83,12 +83,12 @@ alg = Octree(mesh; min_ratio=1e-3, spacing, alpha=1.0)
 """
 struct Octree{M <: Manifold, C <: CRS, T <: Real} <: AbstractNodeGenerationAlgorithm
     triangle_octree::TriangleOctree{M, C, T}
-    boundary_oversampling::Float64
+    boundary_oversampling::T
     placement::Symbol
-    alpha::Float64  # Subdivision aggressiveness: boxes are at most alpha*h_local
+    alpha::T  # Subdivision aggressiveness: boxes are at most alpha*h_local
     node_min_ratio::T  # Node octree minimum box size ratio (can be much finer than triangle octree)
-    bridson_factor::Float64  # Poisson-disk radius relative to h(x) (placement = :bridson only)
-    max_growth::Float64  # Lipschitz cap on |∇h| (0 = off); steep-but-smooth grading
+    bridson_factor::T  # Poisson-disk radius relative to h(x) (placement = :bridson only)
+    max_growth::T  # Lipschitz cap on |∇h| (0 = off); steep-but-smooth grading
 end
 
 # Constructors
@@ -108,17 +108,18 @@ function Octree(
     bridson_factor > 0 || throw(ArgumentError("bridson_factor must be positive"))
     max_growth >= 0 || throw(ArgumentError("max_growth must be ≥ 0 (0 disables the limiter)"))
 
-    # Default: use triangle octree's min_ratio
-    node_ratio = isnothing(node_min_ratio) ? triangle_octree.tree.min_ratio : T(node_min_ratio)
+    # Default: recompute the geometry-based ratio from the octree's mesh
+    node_ratio = isnothing(node_min_ratio) ?
+        _auto_min_ratio(T, triangle_octree.mesh) : T(node_min_ratio)
 
     return Octree{M, C, T}(
         triangle_octree,
-        Float64(boundary_oversampling),
+        T(boundary_oversampling),
         placement,
-        Float64(alpha),
+        T(alpha),
         node_ratio,
-        Float64(bridson_factor),
-        Float64(max_growth),
+        T(bridson_factor),
+        T(max_growth),
     )
 end
 
@@ -139,7 +140,7 @@ function Octree(
         throw(ArgumentError("placement must be :random, :jittered, :lattice, or :bridson"))
     bridson_factor > 0 || throw(ArgumentError("bridson_factor must be positive"))
     max_growth >= 0 || throw(ArgumentError("max_growth must be ≥ 0 (0 disables the limiter)"))
-    T = Float64
+    T = CoordRefSystems.mactype(C)
 
     # Triangle octree: geometry-based or user override
     geometry_min_ratio = isnothing(min_ratio) ? _auto_min_ratio(T, mesh) : T(min_ratio)
@@ -159,7 +160,7 @@ function Octree(
         # Compute from spacing
         h_min = _extract_min_spacing(spacing)
         if !isnothing(h_min)
-            # Compute domain size (strip units to get Float64)
+            # Compute domain size (strip units to the mesh machine type)
             bbox = Meshes.boundingbox(mesh)
             extents = bbox.max - bbox.min
             # Get maximum extent value, stripping units
@@ -181,12 +182,12 @@ function Octree(
 
     return Octree{M, C, T}(
         triangle_octree,
-        Float64(boundary_oversampling),
+        T(boundary_oversampling),
         placement,
-        Float64(alpha),
+        T(alpha),
         node_ratio,
-        Float64(bridson_factor),
-        Float64(max_growth),
+        T(bridson_factor),
+        T(max_growth),
     )
 end
 
@@ -217,11 +218,11 @@ end
 Extract minimum spacing value from spacing object (field access, no sampling).
 """
 function _extract_min_spacing(spacing::ConstantSpacing)
-    return Float64(ustrip(spacing.Δx))
+    return float(ustrip(spacing.Δx))
 end
 
 function _extract_min_spacing(spacing::BoundaryLayerSpacing)
-    return Float64(ustrip(spacing.at_wall))
+    return float(ustrip(spacing.at_wall))
 end
 
 # Fallback for other spacing types: return nothing to indicate unknown
@@ -330,8 +331,9 @@ struct LeafGroup{T <: Real}
     weights::Vector{T}
 end
 
-function _collect_weighted_leaves(node_tree, classification, spacing)
-    T = Float64
+function _collect_weighted_leaves(
+        node_tree::SpatialOctree{<:Any, T}, classification, spacing
+    ) where {T}
     interior, near_surface = LeafGroup(Int[], T[]), LeafGroup(Int[], T[])
 
     for leaf_idx in all_leaves(node_tree)
@@ -339,7 +341,7 @@ function _collect_weighted_leaves(node_tree, classification, spacing)
         if cls == LEAF_INTERIOR || cls == LEAF_BOUNDARY
             # Get spacing at box center (imported from spacing_criterion.jl)
             center = box_center(node_tree, leaf_idx)
-            h_local_raw = T(ustrip(spacing(Point(center...))))
+            h_local_raw = _spacing_value(T, spacing, center)
             h_local = max(h_local_raw, sqrt(eps(T)))
 
             # Weight by volume-to-spacing ratio: larger boxes or finer spacing get more points
@@ -356,8 +358,7 @@ function _collect_weighted_leaves(node_tree, classification, spacing)
     return interior, near_surface
 end
 
-function _generate_from_leaves(leaves::LeafGroup, tree, n_points, placement)
-    T = Float64
+function _generate_from_leaves(leaves::LeafGroup{T}, tree, n_points, placement) where {T}
     counts = _allocate_counts_by_volume(leaves.weights, n_points)
 
     points = SVector{3, T}[]
@@ -493,13 +494,14 @@ function _non_exterior_leaves(node_tree, classification)
 end
 
 """
-    _bridson_h_min(node_tree, classification, spacing) -> Float64
+    _bridson_h_min(node_tree, classification, spacing) -> T
 
 Minimum spacing over non-exterior leaf centers — sets the background grid
-resolution for graded spacing.
+resolution for graded spacing. `T` is the node tree's coordinate type.
 """
-function _bridson_h_min(node_tree, classification, spacing)
-    T = Float64
+function _bridson_h_min(
+        node_tree::SpatialOctree{<:Any, T}, classification, spacing
+    ) where {T}
     leaves = _non_exterior_leaves(node_tree, classification)
     isempty(leaves) && throw(ArgumentError("no non-exterior leaves: cannot run Bridson sampling"))
     h_min = tmapreduce(min, leaves) do idx
@@ -528,8 +530,9 @@ over non-exterior leaves — the discrete spacing integral `∫ 1/h³ dx` with
 headroom for the super-`1/h³` saturated Poisson-disk packing density (see
 [`_estimate_volume_points`](@ref)). It is a non-truncating ceiling, not a target.
 """
-function _estimate_volume_points(node_tree, classification, spacing)
-    T = Float64
+function _estimate_volume_points(
+        node_tree::SpatialOctree{<:Any, T}, classification, spacing
+    ) where {T}
     leaves = _non_exterior_leaves(node_tree, classification)
     isempty(leaves) && return 0
     integral = tmapreduce(+, leaves) do idx
@@ -648,9 +651,9 @@ end
     return _spacing_value(T, s.fallback, c)
 end
 
-function (s::_LeafSpacing)(p::Point)
-    c = SVector{3, Float64}(Float64.(ustrip.(Meshes.to(p)))...)
-    return _spacing_value(Float64, s, c) * s.len_unit
+function (s::_LeafSpacing{T})(p::Point) where {T}
+    c = SVector{3, T}(ustrip.(Meshes.to(p))...)
+    return _spacing_value(T, s, c) * s.len_unit
 end
 
 """
@@ -663,8 +666,9 @@ re-limiting to a fixpoint. Returns the (possibly further-subdivided) tree, the
 refreshed classification, and a `_LeafSpacing` that serves the limited field.
 A no-op tree-wise when `h₀` is already `g`-smooth.
 """
-function _apply_gradient_limit(node_tree, classification, spacing, alg, tri_octree)
-    T = Float64
+function _apply_gradient_limit(
+        node_tree::SpatialOctree{<:Any, T}, classification, spacing, alg, tri_octree
+    ) where {T}
     g = T(alg.max_growth)
     leaves0 = _non_exterior_leaves(node_tree, classification)
     isempty(leaves0) && return node_tree, classification, spacing
@@ -710,7 +714,7 @@ end
 """
     _generate_bridson(node_tree, classification, tri_octree, spacing, seeds,
                       max_points; factor=0.75, k_attempts=30)
-        -> Vector{SVector{3,Float64}}
+        -> Vector{SVector{3,T}}
 
 Graded Bridson Poisson-disk sampling of the domain volume with disk radius
 `factor · h(x)` (see the `Octree` docstring for the choice of `factor`).
@@ -814,9 +818,9 @@ end
 function _discretize_volume(
         _cloud::PointCloud{𝔼{3}, C},
         spacing::AbstractSpacing,
-        alg::Octree;
+        alg::Octree{<:Manifold, <:CRS, T};
         max_points::Union{Int, Nothing} = nothing,
-    ) where {C}
+    ) where {C, T}
     isnothing(alg.triangle_octree.leaf_classification) &&
         throw(
         ArgumentError(
@@ -824,8 +828,6 @@ function _discretize_volume(
                 "Rebuild with: TriangleOctree(mesh; classify_leaves=true)"
         )
     )
-
-    T = Float64
 
     # Bridson is empty when the spacing is too coarse for the domain to host an
     # interior. Clamp (loudly) before the node octree is built — its resolution

--- a/src/discretization/spacing_guidance.jl
+++ b/src/discretization/spacing_guidance.jl
@@ -47,13 +47,13 @@ cloud = discretize(PointBoundary("bunny.stl"), g.h_baseline; alg=Octree("bunny.s
 ```
 """
 function suggest_spacing(
-        mesh::SimpleMesh;
+        mesh::SimpleMesh{M, C};
         n_points::Union{Nothing, Integer} = nothing,
         bridson_factor::Real = 0.75,
         verbose::Bool = true,
         name::AbstractString = "mesh",
-    )
-    T = Float64
+    ) where {M, C}
+    T = CoordRefSystems.mactype(C)
     bmin, bmax = _compute_bbox(T, mesh)
     ext = bmax - bmin
     V = abs(_signed_volume(T, mesh))
@@ -66,17 +66,17 @@ function suggest_spacing(
 end
 
 function suggest_spacing(
-        bnd::PointBoundary;
+        bnd::PointBoundary{M, C};
         n_points::Union{Nothing, Integer} = nothing,
         bridson_factor::Real = 0.75,
         verbose::Bool = true,
         name::AbstractString = "boundary",
-    )
-    T = Float64
+    ) where {M, C}
+    T = CoordRefSystems.mactype(C)
     pts = points(bnd)
     isempty(pts) && throw(ArgumentError("boundary has no points"))
     lu = unit(Meshes.to(first(pts))[1])
-    coords = [SVector{3, T}(T.(ustrip.(Meshes.to(p)))...) for p in pts]
+    coords = [SVector{3, T}(ustrip.(Meshes.to(p))...) for p in pts]
     bmin = reduce((a, b) -> min.(a, b), coords)
     bmax = reduce((a, b) -> max.(a, b), coords)
     ext = bmax - bmin
@@ -172,7 +172,7 @@ end
 
 function _extract_min_spacing(s::_ClampedSpacing)
     im = _extract_min_spacing(s.inner)
-    hm = Float64(ustrip(s.hmax))
+    hm = float(ustrip(s.hmax))
     return isnothing(im) ? hm : min(im, hm)
 end
 
@@ -185,9 +185,9 @@ end
 # sample is too coarse, the interior is unfillable and we clamp.
 function _probe_min_spacing(spacing, bmin::SVector{3, T}, bmax::SVector{3, T}; n::Int = 5) where {T}
     ext = bmax - bmin
-    hmin = T(Inf)
+    hmin = typemax(T)
     for i in 0:(n - 1), j in 0:(n - 1), k in 0:(n - 1)
-        t = SVector{3, T}((i + 0.5) / n, (j + 0.5) / n, (k + 0.5) / n)
+        t = SVector{3, T}(2i + 1, 2j + 1, 2k + 1) / (2n)
         h = _spacing_value(T, spacing, bmin + t .* ext)
         h < hmin && (hmin = h)
     end

--- a/src/discretization/spacings.jl
+++ b/src/discretization/spacings.jl
@@ -14,15 +14,16 @@ concrete implementations.
 abstract type AbstractSpacing end
 abstract type VariableSpacing <: AbstractSpacing end
 
-# O(log n) nearest-neighbor query via KDTree
+# O(log n) nearest-neighbor query via KDTree. Distances come back in the
+# tree's (= boundary data's) machine type regardless of the query point's.
 function _min_distance(p, boundary, tree::KDTree)
-    q = Float64.(ustrip.(to(p)))
+    q = ustrip.(to(p))
     idxs, dists = knn(tree, q, 1)
     return dists[1] * unit(eltype(to(first(boundary))))
 end
 
 function _build_boundary_tree(boundary_points)
-    coords = [Float64.(ustrip.(to(p))) for p in boundary_points]
+    coords = [ustrip.(to(p)) for p in boundary_points]
     return KDTree(coords)
 end
 
@@ -100,8 +101,8 @@ end
 function BoundaryLayerSpacing(boundary_points; at_wall, bulk, layer_thickness)
     isempty(boundary_points) &&
         throw(ArgumentError("boundary_points must be non-empty"))
-    δ = Float64(ustrip(layer_thickness))
-    δ > 0 || throw(ArgumentError("layer_thickness must be positive, got $layer_thickness"))
+    ustrip(layer_thickness) > 0 ||
+        throw(ArgumentError("layer_thickness must be positive, got $layer_thickness"))
 
     # Ensure at_wall and bulk have compatible types
     B = promote_type(typeof(at_wall), typeof(bulk))
@@ -120,10 +121,10 @@ end
 function (s::BoundaryLayerSpacing)(p::Union{Point, Vec})
     # Distance to nearest boundary point
     x = _min_distance(p, s.boundary, s.tree)
-    d = Float64(ustrip(x))
+    d = ustrip(x)
 
     # Sigmoid transition: center at δ/2, width ≈ δ/6 (smooth S-curve over boundary layer)
-    δ = Float64(ustrip(s.layer_thickness))
+    δ = ustrip(s.layer_thickness)
     center = δ / 2
     width = δ / 6
 

--- a/src/metrics.jl
+++ b/src/metrics.jl
@@ -86,20 +86,21 @@ Computes `d_NN(i) / h(x_i)` for every point and returns:
 - `k`, `coord_radius`
 """
 function spacing_fidelity_metrics(
-        cloud::PointCloud, spacing::AbstractSpacing; k = 30, coord_radius = 1.4,
-    )
+        cloud::PointCloud{M, C}, spacing::AbstractSpacing; k = 30, coord_radius = 1.4,
+    ) where {M, C}
+    T = CoordRefSystems.mactype(C)
     pts = points(cloud)
     n = length(pts)
     k = min(n, k)
     method = KNearestSearch(cloud, k)
     results = searchdists(cloud, method)
 
-    dnn_h = Vector{Float64}(undef, n)
+    dnn_h = Vector{T}(undef, n)
     coord = Vector{Int}(undef, n)
     for i in 1:n
         ids, dists = results[i]
         h = ustrip(spacing(pts[i]))
-        d_min = Inf
+        d_min = typemax(T)
         c = 0
         for (j, d) in zip(ids, dists)
             j == i && continue
@@ -113,7 +114,7 @@ function spacing_fidelity_metrics(
 
     μ = mean(dnn_h)
     cv = std(dnn_h) / μ
-    qs = quantile(dnn_h, [0.05, 0.5, 0.95])
+    qs = quantile(dnn_h, T[0.05, 0.5, 0.95])
 
     return (;
         mean_dnn_h = μ,

--- a/src/octree/spacing_criterion.jl
+++ b/src/octree/spacing_criterion.jl
@@ -30,8 +30,8 @@ struct SpacingCriterion{T <: Real, S} <: SubdivisionCriterion
     absolute_min::T
 end
 
-function SpacingCriterion(spacing, diagonal; alpha = 2.0, min_ratio = 1.0e-6)
-    T = Float64
+function SpacingCriterion(spacing, diagonal::Real; alpha = 2, min_ratio = 1.0e-6)
+    T = typeof(float(diagonal))
     return SpacingCriterion{T, typeof(spacing)}(spacing, T(alpha), T(diagonal) * T(min_ratio))
 end
 
@@ -74,7 +74,8 @@ enabling spacing-aware point distribution. The node octree is:
 - `node_min_ratio`: Minimum box size ratio relative to domain
 
 # Returns
-`SpatialOctree{Int, Float64}` with spacing-driven subdivision
+`SpatialOctree{Int, T}` with spacing-driven subdivision, where `T` is the
+triangle octree's coordinate type (the mesh CRS machine type)
 
 # Example
 ```julia
@@ -83,8 +84,9 @@ spacing = BoundaryLayerSpacing(points; at_wall=0.5m, bulk=5m, layer_thickness=2m
 node_tree = build_node_octree(tri_octree, spacing, 1.0, 1e-6)
 ```
 """
-function build_node_octree(triangle_octree, spacing, alpha, node_min_ratio)
-    T = Float64
+function build_node_octree(
+        triangle_octree::TriangleOctree{M, C, T}, spacing, alpha, node_min_ratio
+    ) where {M, C, T}
     bbox_min, bbox_max = bounding_box(triangle_octree.tree)
     node_tree = SpatialOctree{Int, T}(bbox_min, triangle_octree.tree.root_size; initial_capacity = 1000)
 
@@ -101,8 +103,9 @@ end
     return _classify_point_octree(pt, octree; tol = T(tol))
 end
 
-function _box_may_contain_interior(node_tree, box_idx, triangle_octree)
-    T = Float64
+function _box_may_contain_interior(
+        node_tree::SpatialOctree{<:Any, T}, box_idx, triangle_octree
+    ) where {T}
     bbox_min, bbox_max = box_bounds(node_tree, box_idx)
     h = box_size(node_tree, box_idx)
     tol = max(T(_CLASSIFY_TOLERANCE_ABS), h * T(_CLASSIFY_TOLERANCE_REL))

--- a/src/octree/triangle_octree.jl
+++ b/src/octree/triangle_octree.jl
@@ -49,11 +49,11 @@ struct VertexResolutionCriterion{T <: Real} <: SubdivisionCriterion
 end
 
 function VertexResolutionCriterion(
-        mesh::SimpleMesh;
+        mesh::SimpleMesh{M, C};
         tolerance_relative = 1.0e-6,
         min_ratio = 1.0e-6
-    )
-    T = Float64
+    ) where {M, C}
+    T = CoordRefSystems.mactype(C)
     n_triangles = Meshes.nelements(mesh)
     n_triangles > 0 || throw(ArgumentError("Mesh must contain at least one triangle"))
 
@@ -269,7 +269,9 @@ function has_consistent_normals(::Type{T}, mesh::SimpleMesh) where {T}
     return true
 end
 
-has_consistent_normals(mesh::SimpleMesh) = has_consistent_normals(Float64, mesh)
+function has_consistent_normals(mesh::SimpleMesh{M, C}) where {M, C}
+    return has_consistent_normals(CoordRefSystems.mactype(C), mesh)
+end
 
 """
 Signed volume of a closed triangle mesh (divergence theorem,
@@ -321,7 +323,7 @@ function TriangleOctree(
         classify_leaves::Bool = true,
         verify_orientation::Bool = true,
     ) where {M <: Manifold, C <: CRS}
-    T = Float64
+    T = CoordRefSystems.mactype(C)
     n_triangles = Meshes.nelements(mesh)
 
     if verify_orientation && !has_consistent_normals(T, mesh)

--- a/src/repel.jl
+++ b/src/repel.jl
@@ -47,7 +47,9 @@ vanishes at equilibrium.
 - `cull_ratio = 0.0`: after relaxation, drop near-duplicates closer than
   `cull_ratio·spacing` to a kept point. A safety net — a healthy relaxation
   leaves nothing to cull, so a `@warn` is emitted whenever it fires.
-- `convergence`: pass a `Float64[]` to collect the per-iteration force norm.
+- `convergence`: pass an empty float vector (e.g. `Float64[]`) to collect the
+  per-iteration force norm; entries are computed in the cloud's machine type
+  and convert on insertion.
 - `trace`: pass a `NamedTuple[]` to record the closest pair each iteration
   (global boundary-then-volume indices, measured on that iteration's snapshot).
 """
@@ -56,7 +58,7 @@ function repel(
         spacing;
         β = 0.2,
         force_model::RepelForceModel = ClippedSpacingForce(β),
-        α = minimum(spacing.(to(cloud))) * 0.05,
+        α = minimum(spacing.(to(cloud))) / 20,
         α_min = α / 100,
         k = 21,
         max_iters = 1000,
@@ -120,10 +122,10 @@ The returned boundary is a single surface named `:boundary` (use
 function repel(
         cloud::PointCloud{𝔼{3}, C},
         spacing,
-        octree::TriangleOctree;
+        octree::TriangleOctree{<:Manifold, <:CRS, TO};
         β = 0.2,
         force_model::RepelForceModel = ClippedSpacingForce(β),
-        α = minimum(spacing.(to(cloud))) * 0.05,
+        α = minimum(spacing.(to(cloud))) / 20,
         α_min = α / 100,
         k = 21,
         max_iters = 1000,
@@ -136,7 +138,7 @@ function repel(
         deposit_ratio::Real = 0.0,
         convergence::Union{Nothing, AbstractVector{<:AbstractFloat}} = nothing,
         trace::Union{Nothing, AbstractVector{<:NamedTuple}} = nothing,
-    ) where {C <: CRS}
+    ) where {C <: CRS, TO}
     rebuild_every >= 1 || throw(ArgumentError("rebuild_every must be ≥ 1"))
     deposit_ratio >= 0 || throw(ArgumentError("deposit_ratio must be ≥ 0"))
     all_p = points(cloud)
@@ -145,7 +147,7 @@ function repel(
     p, p_old, snap = copy(all_p), copy(all_p), copy(all_p)
 
     len_unit = Unitful.unit(Meshes.to(first(all_p))[1])
-    offset_dist = 1.0e-6 * norm(octree.mesh_bbox_max - octree.mesh_bbox_min)
+    offset_dist = TO(1.0e-6) * norm(octree.mesh_bbox_max - octree.mesh_bbox_min)
     tri_indices = zeros(Int, npoints)
     # Mutable membership: deposition converts volume points into boundary
     # points. Vector{Bool} (not BitVector) — per-slot writes from tmap! tasks
@@ -183,7 +185,7 @@ end
 # ======================================================================
 
 """
-    _relax!(p, p_old, snap, spacing, force_model, constrain; kwargs...) -> Vector{Float64}
+    _relax!(p, p_old, snap, spacing, force_model, constrain; kwargs...) -> Vector{T}
 
 Shared relaxation loop behind both `repel` methods. `p` holds the movable
 points (updated in place); `snap` is the search snapshot whose first `n_fixed`
@@ -195,7 +197,7 @@ given, runs serially after each sweep. Kick targets prefer indices past
 quality-based stops: end when the movable points' d_NN/s CV (read off the
 sweep's nearest-neighbor data, no extra search) reaches the target, or has
 not improved for that many iterations. Returns the force-norm convergence
-history `max_i(|F_i|·s_i)`.
+history `max_i(|F_i|·s_i)` in the points' machine type `T`.
 """
 function _relax!(
         p, p_old, snap, spacing, force_model, constrain;
@@ -206,28 +208,37 @@ function _relax!(
     kk = min(k, length(snap))
     spacings = ustrip.(spacing.(snap))
     len_unit = Unitful.unit(Meshes.to(first(snap))[1])
-    # Force-norm convergence data: at equilibrium forces vanish, so this detects
-    # convergence earlier than displacement (which can be small mid-oscillation).
-    forces = zeros(n_move)
-    # Per-point nearest neighbor, recorded during the sweep — gives the closest
-    # pair for trace/kick without an extra search.
-    nn_dist = fill(Inf, n_move)
-    nn_id = zeros(Int, n_move)
     # Raw-coordinate kd-tree queried via in-place knn! into task-local buffers:
     # the per-query allocations of the generic searchdists path were 66% of the
     # loop's allocations (the tree rebuild itself is only ~3% of its time).
     # Ref so the per-iteration rebuild does not rebind a captured variable
     # (OhMyThreads' tmap! rejects boxed closure captures).
     coords = _raw_point.(snap)
+    T = eltype(eltype(coords))
     tree_ref = Ref(KDTree(coords))
-    buffers = TaskLocalValue{Tuple{Vector{Int}, Vector{Float64}}}(
-        () -> (Vector{Int}(undef, kk), Vector{Float64}(undef, kk))
+    # knn! requires the distance buffer eltype to match the tree's own float
+    # type, so the buffers must carry the cloud's machine type.
+    buffers = TaskLocalValue{Tuple{Vector{Int}, Vector{T}}}(
+        () -> (Vector{Int}(undef, kk), Vector{T}(undef, kk))
     )
-    kick_state = (; pair = (0, 0), rs = Inf, count = 0)
-    best_cv = Inf
+    # Geometry type is authoritative for the step bounds. Fresh names: a rebind
+    # of the captured kwargs would box them inside the sweep closure.
+    αT_lo, αT_max = T(α_lo), T(α_max)
+    # Force-norm convergence data: at equilibrium forces vanish, so this detects
+    # convergence earlier than displacement (which can be small mid-oscillation).
+    forces = zeros(T, n_move)
+    # Per-point nearest neighbor, recorded during the sweep — gives the closest
+    # pair for trace/kick without an extra search.
+    nn_dist = fill(typemax(T), n_move)
+    nn_id = zeros(Int, n_move)
+    # d_NN/s state carries the promoted distance/spacing type so the NamedTuple
+    # and CV comparisons stay type-stable across rebinds.
+    U = typeof(one(T) / one(eltype(spacings)))
+    kick_state = (; pair = (0, 0), rs = typemax(U), count = 0)
+    best_cv = typemax(U)
     last_cv_improvement = 0
 
-    conv = Float64[]
+    conv = T[]
     i = 1
     while i <= max_iters
         p_old .= p
@@ -254,7 +265,7 @@ function _relax!(
             # would drop a genuine nearest neighbor and repel off a self-ghost.
             self = id + n_fixed
             nn_id[id] = 0
-            nn_dist[id] = Inf
+            nn_dist[id] = typemax(T)
             repel_force = zero(_raw_point(xi))
             @inbounds for j in 1:kk
                 ids[j] == self && continue
@@ -271,7 +282,7 @@ function _relax!(
             F_norm = norm(repel_force)
             forces[id] = F_norm * ustrip(s)
             # Adaptive per-point step, capped at one local spacing.
-            α_i = clamp(inv(F_norm + 1.0e-30), α_lo, α_max)
+            α_i = clamp(inv(F_norm + oftype(F_norm, 1.0e-30)), αT_lo, αT_max)
             disp = Vec(s * α_i * repel_force)
             d_norm = norm(disp)
             if d_norm > s
@@ -279,7 +290,7 @@ function _relax!(
             end
             return constrain(id, xi, xi + disp)
         end
-        push!(conv, maximum(forces; init = 0.0))
+        push!(conv, maximum(forces; init = zero(T)))
         if n_move > 0 && (!isnothing(trace) || kick_after > 0)
             pair = _closest_pair(nn_dist, nn_id, spacings, n_fixed)
             isnothing(trace) || push!(trace, (; iteration = i, pair...))
@@ -334,10 +345,9 @@ end
 """
     _raw_point(pt) -> SVector
 
-Unitless Float64 coordinates of a point (dimension-generic). Float32 CRS
-coordinates are promoted so the search tree has a uniform eltype.
+Unitless coordinates of a point in its native machine type (dimension-generic).
 """
-@inline _raw_point(pt) = Float64.(ustrip.(Meshes.to(pt)))
+@inline _raw_point(pt) = ustrip.(Meshes.to(pt))
 
 """
     _safe_direction(xi, xj, r) -> Vec
@@ -354,23 +364,25 @@ function _safe_direction(xi, xj, r)
 end
 
 """
-    _dnn_cv(nn_dist, spacings, n_fixed) -> Float64
+    _dnn_cv(nn_dist, spacings, n_fixed) -> Real
 
 Coefficient of variation of `d_NN/s` over the movable points, read off the
 sweep's per-point nearest-neighbor data. The quality monitor behind
 `stall_after`: it tracks the gate's binding spacing-CV metric for free.
+Computed in the promoted distance/spacing type.
 """
 function _dnn_cv(nn_dist, spacings, n_fixed)
     n = length(nn_dist)
-    s1 = 0.0
-    s2 = 0.0
+    U = typeof(one(eltype(nn_dist)) / one(eltype(spacings)))
+    s1 = zero(U)
+    s2 = zero(U)
     @inbounds for i in 1:n
         u = nn_dist[i] / spacings[i + n_fixed]
         s1 += u
         s2 += u * u
     end
     μ = s1 / n
-    return sqrt(max(s2 / n - μ * μ, 0.0)) / μ
+    return sqrt(max(s2 / n - μ * μ, zero(μ))) / μ
 end
 
 """
@@ -416,7 +428,7 @@ function _maybe_kick!(
     target = a > n_protected ? a : (b > n_protected ? b : (a > n_fixed ? a : b))
     s = spacings[target]
     d = randn(typeof(_raw_point(p[target - n_fixed])))
-    p[target - n_fixed] += Vec(0.1 * s * (d / norm(d)) * len_unit)
+    p[target - n_fixed] += Vec((s / 10) * (d / norm(d)) * len_unit)
     return (; pair = (a, b), rs = pair.r_over_s, count = 0), true
 end
 
@@ -435,18 +447,21 @@ proposed position while it stays inside, and escapees revert — flagged in
 """
 function _constrain_octree(
         id, xi, x_proposed, is_bnd, escaped, tri_indices,
-        octree, offset_dist, len_unit,
-    )
-    sv_proposed = _extract_vertex(Float64, x_proposed)
+        octree::TriangleOctree{<:Manifold, <:CRS, T}, offset_dist, len_unit,
+    ) where {T}
+    # Geometry queries run at the octree's machine type; results convert back
+    # to the point's own machine type before a stored Point is built.
+    sv_proposed = _extract_vertex(T, x_proposed)
     if is_bnd[id]
         sv, tri_idx = _project_to_boundary(sv_proposed, octree, offset_dist)
         if tri_idx == 0
             sv, tri_idx = _project_to_boundary(
-                _extract_vertex(Float64, xi), octree, offset_dist
+                _extract_vertex(T, xi), octree, offset_dist
             )
         end
         tri_indices[id] = tri_idx
-        return Point(sv[1] * len_unit, sv[2] * len_unit, sv[3] * len_unit)
+        svc = CoordRefSystems.mactype(crs(xi)).(sv)
+        return Point(svc[1] * len_unit, svc[2] * len_unit, svc[3] * len_unit)
     end
     isinside(sv_proposed, octree) && return x_proposed
     escaped[id] = true
@@ -466,19 +481,23 @@ conversion is one-way and a parallel pass would over-deposit when a whole
 layer escapes in one iteration.
 """
 function _deposit_escaped!(
-        p, tree, kq, escaped, is_bnd, tri_indices, octree,
+        p, tree, kq, escaped, is_bnd, tri_indices,
+        octree::TriangleOctree{<:Manifold, <:CRS, T},
         spacing, deposit_ratio, offset_dist, len_unit,
-    )
+    ) where {T}
     n_dep = 0
+    isempty(p) && return n_dep
+    Tc = CoordRefSystems.mactype(crs(first(p)))
     for id in eachindex(p)
         escaped[id] || continue
         escaped[id] = false
         is_bnd[id] && continue
         site, tri_idx = _project_to_boundary(
-            _extract_vertex(Float64, p[id]), octree, offset_dist
+            _extract_vertex(T, p[id]), octree, offset_dist
         )
         tri_idx == 0 && continue
-        site_pt = Point(site[1] * len_unit, site[2] * len_unit, site[3] * len_unit)
+        sitec = Tc.(site)
+        site_pt = Point(sitec[1] * len_unit, sitec[2] * len_unit, sitec[3] * len_unit)
         thr = deposit_ratio * ustrip(spacing(site_pt))
         ids_near, _ = knn(tree, _raw_point(site_pt), kq, true)
         occupied = any(
@@ -577,9 +596,10 @@ function _reconstruct_cloud(
     ) where {C <: CRS}
     orig_normals = normal(boundary(cloud))
     orig_areas = area(boundary(cloud))
+    Tc = CoordRefSystems.mactype(C)
 
     new_bnd_pts = Point{𝔼{3}, C}[]
-    new_bnd_normals = SVector{3, Float64}[]
+    new_bnd_normals = eltype(orig_normals)[]
     new_bnd_areas = eltype(orig_areas)[]
     new_vol_pts = Point{𝔼{3}, C}[]
 
@@ -588,7 +608,7 @@ function _reconstruct_cloud(
         if is_bnd[id]
             push!(new_bnd_pts, p[id])
             if tri_indices[id] > 0
-                push!(new_bnd_normals, _get_triangle_normal(Float64, octree.mesh, tri_indices[id]))
+                push!(new_bnd_normals, _get_triangle_normal(Tc, octree.mesh, tri_indices[id]))
             else
                 push!(new_bnd_normals, orig_normals[id])
             end

--- a/src/repel_forces.jl
+++ b/src/repel_forces.jl
@@ -91,7 +91,7 @@ struct ClippedSpacingForce{T <: Real} <: RepelForceModel
 end
 
 ClippedSpacingForce() = ClippedSpacingForce(0.2, 1.0)
-ClippedSpacingForce(β::Real) = ClippedSpacingForce(promote(β, 1.0)...)
+ClippedSpacingForce(β::Real) = ClippedSpacingForce(promote(β, 1)...)
 
 @inline function compute_force(m::ClippedSpacingForce, u::Real)
     u² = u * u
@@ -119,7 +119,7 @@ struct StrongSpacingForce{T <: Real} <: RepelForceModel
 end
 
 StrongSpacingForce() = StrongSpacingForce(0.2, 3.0)
-StrongSpacingForce(β::Real) = StrongSpacingForce(promote(β, 3.0)...)
+StrongSpacingForce(β::Real) = StrongSpacingForce(promote(β, 3)...)
 
 @inline function compute_force(m::StrongSpacingForce, u::Real)
     u² = u * u

--- a/src/surface_sampling.jl
+++ b/src/surface_sampling.jl
@@ -32,13 +32,13 @@ until `max_points` is reached (with a warning, since a truncated pass leaves the
 surface under-sampled).
 """
 function sample_surface(
-        mesh::SimpleMesh{𝔼{3}},
+        mesh::SimpleMesh{𝔼{3}, C},
         spacing::AbstractSpacing;
         factor::Real = 0.75,
         max_points::Int = 10_000_000,
         stall_limit::Int = 2000,
-    )
-    T = Float64
+    ) where {C}
+    T = CoordRefSystems.mactype(C)
     factor > 0 || throw(ArgumentError("factor must be positive"))
     stall_limit > 0 || throw(ArgumentError("stall_limit must be positive"))
     n_tri = nelements(mesh)
@@ -47,9 +47,9 @@ function sample_surface(
 
     # Triangle areas (for area-weighted sampling) and domain bounds.
     tri_areas = Vector{T}(undef, n_tri)
-    gmin = SVector{3, T}(Inf, Inf, Inf)
-    gmax = SVector{3, T}(-Inf, -Inf, -Inf)
-    r_min = T(Inf)
+    gmin = SVector{3, T}(typemax(T), typemax(T), typemax(T))
+    gmax = SVector{3, T}(typemin(T), typemin(T), typemin(T))
+    r_min = typemax(T)
     for i in 1:n_tri
         v1, v2, v3 = _get_triangle_vertices(T, mesh, i)
         tri_areas[i] = norm(cross(v2 - v1, v3 - v1)) / 2

--- a/test/cloud.jl
+++ b/test/cloud.jl
@@ -241,6 +241,19 @@ end
     @test length(cloud) == 4
 end
 
+@testitem "PointCloud mactype promotion for mixed types" setup = [CommonImports] begin
+    # A Float32 boundary combined with a Float64 volume must promote both
+    # sides to the common type (Float64) and keep names and counts intact.
+    pts32 = [Point(0.0f0, 0.0f0, 0.0f0), Point(1.0f0, 0.0f0, 0.0f0), Point(0.0f0, 1.0f0, 0.0f0)]
+    bnd = PointBoundary(pts32)
+    vol = PointVolume([Point(0.5, 0.5, 0.5)])
+    cloud = PointCloud(bnd, vol, NoTopology())
+    @test CoordRefSystems.mactype(Meshes.crs(first(points(cloud)))) === Float64
+    @test length(cloud) == 4
+    @test length(WhatsThePoint.boundary(cloud)) == 3
+    @test names(cloud) == names(bnd)
+end
+
 @testitem "PointCloud rejects CRS differing beyond machine type" setup = [CommonImports] begin
     # Promotion reconciles only the mactype. A boundary in mm and a volume in
     # m share Float64, so promotion is a no-op and the CRS still differ — the

--- a/test/float32_pipeline.jl
+++ b/test/float32_pipeline.jl
@@ -1,0 +1,63 @@
+@testitem "Float32 pipeline: octree, discretize, sampling, guidance" setup = [CommonImports, OctreeTestData] begin
+    # End-to-end machine-type preservation: a Float32 mesh must flow Float32
+    # through TriangleOctree, the Octree algorithm, discretize, sample_surface,
+    # and suggest_spacing — no silent promotion to Float64. Assertions are
+    # type-level only; point quality on a coarse Float32 cube is not the target.
+    mesh32 = OctreeTestData.unit_cube_mesh(Float32)
+    @test CoordRefSystems.mactype(Meshes.crs(mesh32)) === Float32
+    sp = ConstantSpacing(0.25f0u"m")
+
+    tri = TriangleOctree(mesh32; classify_leaves = true)
+    @test tri.tree isa WhatsThePoint.SpatialOctree{Int, Float32}
+    @test eltype(tri.mesh_bbox_min) === Float32
+
+    # Octree(tri_octree) without node_min_ratio recomputes the geometry ratio
+    # from the mesh (regression: read a nonexistent tree.min_ratio field).
+    alg_from_tri = Octree(tri)
+    @test alg_from_tri.node_min_ratio isa Float32
+
+    alg = Octree(mesh32; spacing = sp)
+    @test alg.alpha isa Float32
+    @test alg.boundary_oversampling isa Float32
+    @test alg.bridson_factor isa Float32
+    @test alg.max_growth isa Float32
+    @test alg.node_min_ratio isa Float32
+
+    cloud = discretize(PointBoundary(mesh32), sp; alg, max_points = 200)
+    @test CoordRefSystems.mactype(Meshes.crs(first(points(cloud)))) === Float32
+    @test length(WhatsThePoint.volume(cloud)) > 0
+
+    surf = sample_surface(mesh32, sp)
+    @test CoordRefSystems.mactype(Meshes.crs(first(points(surf)))) === Float32
+    @test eltype(WhatsThePoint.normal(surf)) <: SVector{3, Float32}
+    @test ustrip(first(WhatsThePoint.area(surf))) isa Float32
+
+    g = suggest_spacing(mesh32; verbose = false)
+    @test ustrip(g.h_ceiling) isa Float32
+    @test ustrip(g.h_baseline) isa Float32
+    @test ustrip(g.h_fine) isa Float32
+end
+
+@testitem "Float32 pipeline: repel and spacing fidelity metrics" setup = [CommonImports, OctreeTestData] begin
+    mesh32 = OctreeTestData.unit_cube_mesh(Float32)
+    sp = ConstantSpacing(0.25f0u"m")
+    tri = TriangleOctree(mesh32; classify_leaves = true)
+    cloud = discretize(
+        PointBoundary(mesh32), sp; alg = Octree(mesh32; spacing = sp), max_points = 200
+    )
+
+    c_vol = repel(cloud, sp; β = 0.2f0, max_iters = 3)
+    @test CoordRefSystems.mactype(Meshes.crs(first(points(c_vol)))) === Float32
+
+    # A user-supplied Float64 convergence vector keeps working: entries are
+    # computed in Float32 and convert on insertion.
+    conv = Float64[]
+    c_oct = repel(cloud, sp, tri; β = 0.2f0, max_iters = 3, convergence = conv)
+    @test CoordRefSystems.mactype(Meshes.crs(first(points(c_oct)))) === Float32
+    @test length(conv) == 3
+
+    fm = spacing_fidelity_metrics(cloud, sp; k = 8)
+    @test fm.mean_dnn_h isa Float32
+    @test fm.cv isa Float32
+    @test fm.p05 isa Float32 && fm.p50 isa Float32 && fm.p95 isa Float32
+end

--- a/test/octree.jl
+++ b/test/octree.jl
@@ -383,36 +383,51 @@ end
     @test alg2.triangle_octree isa WhatsThePoint.TriangleOctree
 end
 
-@testitem "Octree discretization promotes Float32 STL boundaries" setup = [TestData, CommonImports] begin
-    # The Octree algorithm emits Float64 volume points. A boundary with a
-    # different mactype (e.g. Float32 from binary STL) must still assemble into
-    # a single-CRS PointCloud — the PointCloud constructor promotes boundary
-    # and volume to their common type automatically.
-    #
+@testitem "Octree discretization preserves and promotes mactype" setup = [TestData, CommonImports] begin
     # GeoIO's output mactype is version-dependent (newer Meshes/CoordRefSystems
     # promote binary STL to Float64 on load), so we explicitly rebuild the mesh
-    # with Float32 coordinates to guarantee the mixed-mactype path is
-    # exercised regardless of the resolved dependency versions.
+    # at a known mactype to pin both paths regardless of the resolved
+    # dependency versions.
     mesh_raw = GeoIO.load(TestData.BOX_PATH).geometry
-    to_f32(p) = (c = Meshes.coords(p); Meshes.Point(Float32(ustrip(c.x)), Float32(ustrip(c.y)), Float32(ustrip(c.z))))
-    mesh_f32 = Meshes.SimpleMesh(to_f32.(Meshes.vertices(mesh_raw)), Meshes.topology(mesh_raw))
+    rebuild(T, mesh) = Meshes.SimpleMesh(
+        [
+            (c = Meshes.coords(p); Meshes.Point(T(ustrip(c.x)), T(ustrip(c.y)), T(ustrip(c.z))))
+                for p in Meshes.vertices(mesh)
+        ],
+        Meshes.topology(mesh),
+    )
+    mesh_f32 = rebuild(Float32, mesh_raw)
     bnd = PointBoundary(mesh_f32)
     @test CoordRefSystems.mactype(Meshes.crs(first(points(bnd)))) === Float32
 
-    alg = Octree(mesh_f32)
-    cloud = discretize(bnd, ConstantSpacing(3.0m); alg, max_points = 50)
-    @test cloud isa PointCloud
-    @test length(WhatsThePoint.volume(cloud)) > 0
-    # Cloud mactype is the promoted common type (Float32 + Float64 -> Float64)
-    @test CoordRefSystems.mactype(Meshes.crs(first(points(cloud)))) === Float64
+    # Type-consistent path: a Float32 mesh drives a Float32 algorithm, and the
+    # whole pipeline stays Float32 — no silent promotion to Float64.
+    alg32 = Octree(mesh_f32)
+    @test alg32.alpha isa Float32
+    @test alg32.boundary_oversampling isa Float32
+    @test alg32.bridson_factor isa Float32
+    @test alg32.max_growth isa Float32
+    @test eltype(alg32.triangle_octree.mesh_bbox_min) === Float32
+    cloud32 = discretize(bnd, ConstantSpacing(3.0f0m); alg = alg32, max_points = 50)
+    @test cloud32 isa PointCloud
+    @test length(WhatsThePoint.volume(cloud32)) > 0
+    @test CoordRefSystems.mactype(Meshes.crs(first(points(cloud32)))) === Float32
+
+    # Mixed path: a Float32 boundary combined with a deliberately Float64
+    # algorithm still assembles — the PointCloud constructor promotes boundary
+    # and volume to their common type (Float32 + Float64 -> Float64).
+    mesh_f64 = rebuild(Float64, mesh_raw)
+    cloud_mixed = discretize(bnd, ConstantSpacing(3.0m); alg = Octree(mesh_f64), max_points = 50)
+    @test length(WhatsThePoint.volume(cloud_mixed)) > 0
+    @test CoordRefSystems.mactype(Meshes.crs(first(points(cloud_mixed)))) === Float64
 
     # Promotion preserves surface names (and the boundary point count).
-    @test names(WhatsThePoint.boundary(cloud)) == names(bnd)
-    @test length(WhatsThePoint.boundary(cloud)) == length(bnd)
+    @test names(WhatsThePoint.boundary(cloud_mixed)) == names(bnd)
+    @test length(WhatsThePoint.boundary(cloud_mixed)) == length(bnd)
 
     # Non-Octree algorithms are untouched: same Float32 boundary still works
-    # through SlakKosec without promotion.
+    # through SlakKosec.
     octree = TriangleOctree(TestData.BOX_PATH; classify_leaves = true)
-    cloud32 = discretize(bnd, ConstantSpacing(3.0f0m); alg = SlakKosec(octree), max_points = 20)
-    @test cloud32 isa PointCloud
+    cloud_sk = discretize(bnd, ConstantSpacing(3.0f0m); alg = SlakKosec(octree), max_points = 20)
+    @test cloud_sk isa PointCloud
 end

--- a/test/repel.jl
+++ b/test/repel.jl
@@ -169,13 +169,17 @@ end
     @test StrongSpacingForce().γ == 3.0
     @test StrongSpacingForce(0.5).γ == 3.0
 
-    # One-arg constructor promotes non-Float64 β like ClippedSpacingForce does
-    # (regression: Float32/Int β hit the same-type default constructor and
-    # threw a MethodError).
+    # One-arg constructor preserves β's machine type instead of promoting to
+    # Float64 (regression: `promote(β, 3.0)` silently stored Float32 β as
+    # Float64 — the old `m7.β == 0.5f0` check passed numerically anyway).
     m7 = StrongSpacingForce(0.5f0)
-    @test m7.β == 0.5f0 && m7.γ == 3.0
+    @test m7 isa StrongSpacingForce{Float32}
+    @test m7.β == 0.5f0 && m7.γ == 3.0f0
     m8 = StrongSpacingForce(1)
-    @test m8.β == 1.0 && m8.γ == 3.0
+    @test m8 isa StrongSpacingForce{Int}
+    @test m8.β == 1 && m8.γ == 3
+    @test ClippedSpacingForce(0.5f0) isa ClippedSpacingForce{Float32}
+    @test ClippedSpacingForce(0.5f0).u0 == 1.0f0
 end
 
 @testitem "repel β kwarg feeds default force_model" setup = [TestData, CommonImports] begin

--- a/test/testsetup.jl
+++ b/test/testsetup.jl
@@ -29,13 +29,14 @@ end
     using Meshes: Point, SimpleMesh, connect
     import Meshes
 
-    """Unit cube mesh: 8 vertices, 12 triangles (2 per face, CCW from outside)."""
-    function unit_cube_mesh()
+    """Unit cube mesh: 8 vertices, 12 triangles (2 per face, CCW from outside).
+    `T` sets the coordinate machine type (default Float64)."""
+    function unit_cube_mesh(::Type{T} = Float64) where {T}
         pts = [
-            Point(0.0, 0.0, 0.0), Point(1.0, 0.0, 0.0),
-            Point(1.0, 1.0, 0.0), Point(0.0, 1.0, 0.0),
-            Point(0.0, 0.0, 1.0), Point(1.0, 0.0, 1.0),
-            Point(1.0, 1.0, 1.0), Point(0.0, 1.0, 1.0),
+            Point(T(0), T(0), T(0)), Point(T(1), T(0), T(0)),
+            Point(T(1), T(1), T(0)), Point(T(0), T(1), T(0)),
+            Point(T(0), T(0), T(1)), Point(T(1), T(0), T(1)),
+            Point(T(1), T(1), T(1)), Point(T(0), T(1), T(1)),
         ]
         connec = [
             connect((1, 3, 2), Meshes.Triangle), connect((1, 4, 3), Meshes.Triangle),


### PR DESCRIPTION
Removes the Float64 hardcoding that PR #100 introduced (and the pre-existing pins it inherited) so the numeric type flows from the input geometry through the whole pipeline. Follows the `_promote_mactype` design in `src/cloud.jl`: types are derived and kept consistent, never auto-converted to Float64.

## What changed

- **Entry points derive `T = CoordRefSystems.mactype(C)`** (the existing SlakKosec idiom) instead of binding `T = Float64`: `TriangleOctree`, `VertexResolutionCriterion`, both `Octree` ctors, `_discretize_volume`, `suggest_spacing`, `sample_surface`, `spacing_fidelity_metrics`. Internal helpers recover `T` from type parameters via where-clauses (`SpatialOctree{<:Any,T}`, `LeafGroup{T}`, ...).
- **`Octree` struct**: `boundary_oversampling`/`alpha`/`bridson_factor`/`max_growth` are now `T` with `T(...)` ctor conversions.
- **repel**: `_raw_point` no longer promotes to Float64; knn!/force/convergence buffers are typed off the cloud (the knn! buffer typing is load-bearing — NearestNeighbors ≥ 0.4.27 throws on an eltype mismatch); geometry queries run at the octree's `T`, projected results convert back to the cloud's machine type before Points are stored.
- **Force ctors** promote with integer literals (`promote(β, 3)`), so `ClippedSpacingForce(0.5f0)` is genuinely `{Float32}`.
- **Type-poisoning literals** replaced with typed forms (`oftype` guard, `typemax(T)`, `quantile(dnn_h, T[...])`, `/20` instead of `* 0.05`).

## Also in here

- Fixes a latent crash: `Octree(tri_octree)` without `node_min_ratio` read the nonexistent `tree.min_ratio` field; it now recomputes `_auto_min_ratio` from the mesh.
- Behavior note: a Float32 mesh through the Octree algorithm now yields a Float32 cloud (previously promoted to Float64), matching what SlakKosec already did. The mixed-mactype `PointCloud` promotion ctor stays as the reconciliation shim and keeps direct test coverage.

## Tests

- New `test/float32_pipeline.jl`: end-to-end Float32 type assertions across TriangleOctree/discretize/repel/sample_surface/suggest_spacing/metrics, including `convergence = Float64[]` back-compat.
- Rewrote the mixed-mactype octree test to cover both the preserve (Float32→Float32) and promote (Float32 boundary + Float64 alg → Float64) paths; added a direct promotion unit test in `test/cloud.jl`; strengthened force-ctor assertions to type level.

Verified locally: package loads, and an e2e script confirms Float32 preservation, an unchanged Float64 path, and the promotion shim on mixed inputs.

---
<sub>🤖 Typed with parametric precision by Claude — Kyle just picked the branch name.</sub>