### PR TITLE
feat!: require explicit units at mesh import

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -169,8 +169,8 @@ hastopology(cloud)  # true if topology exists
 ```julia
 using WhatsThePoint
 
-# Import boundary from STL
-boundary = PointBoundary("path/to/file.stl")
+# Import boundary from STL (unit required — mesh files carry no unit metadata)
+boundary = PointBoundary("path/to/file.stl", u"m")
 
 # Define spacing
 spacing = ConstantSpacing(1m)
@@ -198,7 +198,7 @@ split_surface!(boundary, 75°)
 cloud = repel(cloud, spacing; β=0.2, max_iters=1000)
 
 # Boundary-aware repulsion (3D only) — all points move, escaped points projected back
-octree = TriangleOctree("model.stl"; classify_leaves=true)
+octree = TriangleOctree(import_mesh("model.stl", u"m"); classify_leaves=true)
 cloud = repel(cloud, spacing, octree; β=0.2, max_iters=1000)
 
 # Production configuration: standoff kicks + quality-based stopping
@@ -250,7 +250,7 @@ visualize(boundary; markersize=0.15)
 - `repel` - Optimize point distribution via node repulsion; two methods: `repel(cloud, spacing)` volume-only, `repel(cloud, spacing, octree)` boundary-projected (returns new cloud)
 - `isinside` - Test if point is inside domain
 - `metrics` / `spacing_metrics` / `spacing_fidelity_metrics` - Distribution quality (separation, fill, mesh ratio, d_NN/h statistics)
-- `import_surface` - Load from STL/mesh files (via GeoIO.jl)
+- `import_mesh` / `import_surface` - Load from STL/mesh files (via GeoIO.jl) with a required unit that reinterprets the raw coordinates; `geometry_info` probes raw extents first
 - `save` - Save to file (`:jld2` default, or `:vtk` format)
 - `export_vtk` - ParaView `.vtu` export with point_type/surface_id and optional solution fields
 - `visualize` - Makie-based visualization

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ A Julia package for generating and manipulating point clouds for meshless PDE me
 ## Features
 
 - **Spacing guidance** — `suggest_spacing` probes a geometry and recommends a baseline node spacing before you generate anything
-- **Surface import** from STL and other mesh formats via [GeoIO.jl](https://github.com/JuliaEarth/GeoIO.jl), plus **Poisson-disk surface sampling** (`PointBoundary(mesh, spacing)`) at a prescribed spacing
+- **Surface import** from STL and other mesh formats via [GeoIO.jl](https://github.com/JuliaEarth/GeoIO.jl) with **explicit units** (mesh files carry none — `import_mesh("part.stl", u"mm")` says what the numbers mean), plus **Poisson-disk surface sampling** (`PointBoundary(mesh, spacing)`) at a prescribed spacing
 - **Volume discretization** with multiple algorithms:
   - `SlakKosec` and `VanDerSandeFornberg` (3D)
   - `FornbergFlyer` (2D)
@@ -40,8 +40,8 @@ A Julia package for generating and manipulating point clouds for meshless PDE me
 ```julia
 using WhatsThePoint, Unitful
 
-# Import a surface mesh
-boundary = PointBoundary("model.stl")
+# Import a surface mesh — the unit says what the file's raw numbers mean
+boundary = PointBoundary("model.stl", u"mm")
 
 # Split surfaces by normal angle
 split_surface!(boundary, 75°)

--- a/docs/generate_images.jl
+++ b/docs/generate_images.jl
@@ -20,7 +20,7 @@ mkpath(ASSETS_DIR)
 
 function bunny_silhouette(; n_bins = 200)
     stl_path = joinpath(@__DIR__, "src", "assets", "bunny.stl")
-    boundary3d = WTP.PointBoundary(stl_path)
+    boundary3d = WTP.PointBoundary(stl_path, m)
     coords = WTP.to(boundary3d)
 
     # Project to XZ plane (side view)

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -121,6 +121,12 @@ spacing_fidelity_metrics
 suggest_spacing
 ```
 
+## Geometry Inspection
+
+```@docs
+geometry_info
+```
+
 ## Surface Sampling
 
 ```@docs
@@ -130,6 +136,7 @@ sample_surface
 ## I/O
 
 ```@docs
+import_mesh
 import_surface
 save
 export_vtk

--- a/docs/src/concepts.md
+++ b/docs/src/concepts.md
@@ -91,6 +91,8 @@ split_surface!(boundary, 75°)
 
 Units propagate through all operations — point coordinates, normals, areas, and spacing values all carry their units consistently.
 
+Units enter the pipeline at import: mesh files carry no unit metadata, so every file-loading entry point (`import_mesh`, `PointBoundary`, `import_surface`, `suggest_spacing`) requires the unit the file's raw numbers are meant in, and *reinterprets* them in that unit (a stored `46` becomes `46 mm` — no conversion).
+
 ## Parallelism
 
 WhatsThePoint uses [OhMyThreads.jl](https://github.com/JuliaFolds2/OhMyThreads.jl) for threaded execution. The following operations are parallelized:

--- a/docs/src/discretization.md
+++ b/docs/src/discretization.md
@@ -39,7 +39,7 @@ Adaptive 3D octree-based algorithm that uses the provided spacing function to de
 The default placement mode is `:bridson` — a single global advancing-front Poisson-disk pass (Bridson 2007), graded to the spacing field and seeded from the boundary points, so every generated point keeps its distance from every other point *and* the wall by construction. The front stops on its own once the domain is saturated, so `max_points` can be left unset (it becomes a non-truncating cap estimated from the spacing integral). Per-leaf `:random`, `:jittered`, and `:lattice` placements remain available.
 
 ```julia
-mesh = GeoIO.load("model.stl").geometry
+mesh = import_mesh("model.stl", u"m")
 
 spacing = BoundaryLayerSpacing(
 	points(PointBoundary(mesh));
@@ -70,7 +70,7 @@ cloud = discretize(boundary, spacing; alg=SlakKosec())
 cloud = discretize(boundary, spacing; alg=SlakKosec(20))
 
 # With octree acceleration for faster isinside queries
-octree = TriangleOctree("model.stl"; min_ratio=1e-6)
+octree = TriangleOctree(import_mesh("model.stl", u"m"); min_ratio=1e-6)
 cloud = discretize(boundary, spacing; alg=SlakKosec(octree))
 cloud = discretize(boundary, spacing; alg=SlakKosec(20, octree))
 ```

--- a/docs/src/guide.md
+++ b/docs/src/guide.md
@@ -8,12 +8,27 @@ This guide walks through the core workflow: importing a surface, generating volu
 
 ## Importing a Surface
 
-Load a surface mesh (STL, OBJ, or any format supported by [GeoIO.jl](https://github.com/JuliaEarth/GeoIO.jl)) as a `PointBoundary`:
+Mesh files carry no unit metadata — the coordinates are just numbers, and CAD tools commonly export in millimeters or inches. Every file entry point therefore requires the unit those numbers are meant in; inspect first when unsure:
 
 ```julia
 using WhatsThePoint
+using Unitful: mm
 
-boundary = PointBoundary("model.stl")
+geometry_info("intake.stl")
+# ─── intake.stl ───
+#   min:    (0.0, 0.0, 0.0)
+#   max:    (120.5, 87.3, 42.0)    ← looks like mm
+#   extent: (120.5, 87.3, 42.0)
+
+boundary = PointBoundary("intake.stl", mm)  # 120.5 becomes 120.5 mm, not 0.1205 mm
+```
+
+The unit *reinterprets* the stored numbers — no conversion happens. When the mesh itself is needed downstream (octrees, surface sampling), load it once through [`import_mesh`](@ref) and share it:
+
+```julia
+mesh = import_mesh("model.stl", mm)
+boundary = PointBoundary(mesh)
+octree = TriangleOctree(mesh; classify_leaves=true)
 ```
 
 !!! note "Face centers, not vertices"
@@ -22,7 +37,7 @@ boundary = PointBoundary("model.stl")
 To place boundary points at a spacing *you* choose instead of the one the tessellation dictates, Poisson-disk sample the surface:
 
 ```julia
-mesh = GeoIO.load("model.stl").geometry
+mesh = import_mesh("model.stl", mm)
 boundary = PointBoundary(mesh, spacing)   # blue-noise samples at spacing(x)
 ```
 
@@ -78,7 +93,7 @@ Generate volume points from a boundary using `discretize`. The algorithm choice 
 Before committing to a spacing, probe the geometry:
 
 ```julia
-g = suggest_spacing("model.stl")   # extent, volume, h_ceiling / h_baseline / h_fine
+g = suggest_spacing("model.stl", u"m")   # extent, volume, h_ceiling / h_baseline / h_fine
 spacing = ConstantSpacing(g.h_baseline)
 ```
 
@@ -95,14 +110,15 @@ cloud = discretize(boundary, spacing; alg=VanDerSandeFornberg(), max_points=100_
 
 # Octree — spacing-driven adaptive fill; the default :bridson placement is a
 # global graded Poisson-disk front, and max_points is auto-estimated when unset
+mesh = import_mesh("model.stl", u"m")
 bl_spacing = BoundaryLayerSpacing(points(boundary); at_wall=0.6m, bulk=4.0m, layer_thickness=8.0m)
-cloud = discretize(boundary, bl_spacing; alg=Octree("model.stl"))
+cloud = discretize(boundary, bl_spacing; alg=Octree(mesh))
 ```
 
 `SlakKosec` can also accept a `TriangleOctree` for accelerated point-in-volume queries:
 
 ```julia
-octree = TriangleOctree("model.stl"; min_ratio=1e-6)
+octree = TriangleOctree(mesh; min_ratio=1e-6)
 cloud = discretize(boundary, spacing; alg=SlakKosec(octree))
 ```
 
@@ -144,7 +160,7 @@ The Octree algorithm's default Bridson placement delivers blue-noise quality by 
 cloud = repel(cloud, spacing; β=0.2, max_iters=1000)
 
 # Boundary-aware (3D) — all points move, escaped points projected back to surface
-octree = TriangleOctree("model.stl"; classify_leaves=true)
+octree = TriangleOctree(import_mesh("model.stl", u"m"); classify_leaves=true)
 cloud = repel(cloud, spacing, octree; β=0.2, max_iters=1000)
 
 # Collect convergence history via keyword

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -23,7 +23,8 @@ Load a surface mesh and inspect the boundary structure:
 
 ```@example quickstart
 using WhatsThePoint
-boundary = PointBoundary(joinpath(@__DIR__, "assets/bunny.stl"))
+using Unitful: m
+boundary = PointBoundary(joinpath(@__DIR__, "assets/bunny.stl"), m)
 ```
 
 ```julia
@@ -56,8 +57,8 @@ Pkg.add(url="https://github.com/JuliaMeshless/WhatsThePoint.jl")
 ## Key Features
 
 **Pipeline**
-- Spacing guidance before generation via `suggest_spacing`
-- Import surface meshes (STL, OBJ, any GeoIO.jl format) or Poisson-disk sample them at a prescribed spacing (`PointBoundary(mesh, spacing)`)
+- Spacing guidance before generation via `suggest_spacing`, raw-extent probing via `geometry_info`
+- Import surface meshes (STL, OBJ, any GeoIO.jl format) with explicit units via `import_mesh`, or Poisson-disk sample them at a prescribed spacing (`PointBoundary(mesh, spacing)`)
 - Multiple discretization algorithms: `SlakKosec`, `VanDerSandeFornberg` (3D), `FornbergFlyer` (2D), `Octree` (default `:bridson` graded Poisson-disk fill)
 - Node repulsion for distribution optimization (Miotti 2023)
 - Quality metrics: `metrics`, `spacing_metrics`, `spacing_fidelity_metrics`

--- a/docs/src/isinside_octree.md
+++ b/docs/src/isinside_octree.md
@@ -32,13 +32,10 @@ For large 3D meshes, the Green's function approach becomes expensive. The [`Tria
 
 ```julia
 using WhatsThePoint
+using Unitful: mm
 
-# From a file path
-octree = TriangleOctree("model.stl"; min_ratio=1e-6)
-
-# From a SimpleMesh
-using GeoIO
-mesh = GeoIO.load("model.stl") |> boundary
+# Load the mesh once (unit required — files carry no unit metadata)
+mesh = import_mesh("model.stl", mm)
 octree = TriangleOctree(mesh; min_ratio=1e-6)
 ```
 
@@ -67,7 +64,7 @@ This classification enables O(1) point-in-volume queries for interior and exteri
 ### Octree-Accelerated isinside
 
 ```julia
-octree = TriangleOctree("model.stl"; min_ratio=1e-6)
+octree = TriangleOctree(import_mesh("model.stl", mm); min_ratio=1e-6)
 
 # Single point query
 result = isinside(point, octree)
@@ -87,7 +84,7 @@ Both `SVector{3}` and Meshes.jl `Point` types are accepted.
 Pass a `TriangleOctree` to `SlakKosec` to accelerate the `isinside` checks during volume point generation:
 
 ```julia
-octree = TriangleOctree("model.stl"; min_ratio=1e-6)
+octree = TriangleOctree(import_mesh("model.stl", mm); min_ratio=1e-6)
 spacing = ConstantSpacing(1mm)
 cloud = discretize(boundary, spacing; alg=SlakKosec(octree))
 ```
@@ -97,7 +94,8 @@ cloud = discretize(boundary, spacing; alg=SlakKosec(octree))
 `Octree` uses the octree directly to generate volume points. See the [Discretization](discretization.md) page for details.
 
 ```julia
-cloud = discretize(boundary, spacing; alg=Octree("model.stl"), max_points=200_000)
+mesh = import_mesh("model.stl", mm)
+cloud = discretize(boundary, spacing; alg=Octree(mesh), max_points=200_000)
 ```
 
 ## Choosing an Approach

--- a/docs/src/octree.md
+++ b/docs/src/octree.md
@@ -15,10 +15,9 @@ This is useful for CFD and boundary-layer-dominated meshless simulations where y
 
 ```julia
 using WhatsThePoint
-using GeoIO
 using Unitful: m
 
-mesh = GeoIO.load("model.stl").geometry
+mesh = import_mesh("model.stl", m)
 boundary = PointBoundary(mesh)
 
 spacing = BoundaryLayerSpacing(

--- a/docs/src/quickstart.md
+++ b/docs/src/quickstart.md
@@ -15,9 +15,10 @@ Pkg.add(url="https://github.com/JuliaMeshless/WhatsThePoint.jl")
 
 ```julia
 using WhatsThePoint
+using Unitful: mm
 
-# 1. Import a surface mesh
-boundary = PointBoundary("model.stl")
+# 1. Import a surface mesh — the unit says what the file's raw numbers mean
+boundary = PointBoundary("model.stl", mm)
 
 # 2. Split into named surfaces by normal angle
 split_surface!(boundary, 75°)
@@ -40,7 +41,7 @@ export_vtk("cloud", cloud)
 ```
 
 !!! tip "Not sure what spacing to use?"
-    Run `suggest_spacing("model.stl")` first — it probes the geometry and
+    Run `suggest_spacing("model.stl", mm)` first — it probes the geometry and
     recommends a baseline spacing (plus the coarsest spacing the domain can
     host before the interior comes out empty).
 

--- a/docs/src/repel.md
+++ b/docs/src/repel.md
@@ -25,7 +25,7 @@ Only volume (interior) points move. Boundary points remain fixed. Any volume poi
 ### Boundary-aware (with `TriangleOctree`, 3D only)
 
 ```julia
-octree = TriangleOctree("model.stl"; classify_leaves=true)
+octree = TriangleOctree(import_mesh("model.stl", u"m"); classify_leaves=true)
 cloud = repel(cloud, spacing, octree; β=0.2, max_iters=1000)
 ```
 

--- a/examples/bunny_discretization.jl
+++ b/examples/bunny_discretization.jl
@@ -3,7 +3,7 @@ using Unitful: m
 using GLMakie
 using GeoIO
 
-mesh = GeoIO.load("bunny.stl").geometry
+mesh = import_mesh("bunny.stl", m)
 
 # Step 2: (Optional) Preprocess mesh with Meshes.jl
 # mesh = refine(mesh)

--- a/examples/octree_boundary_layer.jl
+++ b/examples/octree_boundary_layer.jl
@@ -49,11 +49,11 @@ isfile(MESH_PATH) || error(
 )
 
 # A quick spacing sanity check before committing to a long run (the "step 0"):
-suggest_spacing(MESH_PATH; name = MESH_PATH)
+suggest_spacing(MESH_PATH, m; name = MESH_PATH)
 println()
 
 println("Loading mesh...")
-@time mesh = GeoIO.load(MESH_PATH).geometry
+@time@time mesh = import_mesh(MESH_PATH, m)
 println("Mesh: $(nelements(mesh)) triangles\n")
 
 # Boundary-layer spacing keyed on the imported boundary points (KDTree-accelerated).

--- a/examples/octree_uniform.jl
+++ b/examples/octree_uniform.jl
@@ -3,7 +3,7 @@ using GLMakie
 using GeoIO
 using Unitful: m
 
-mesh = GeoIO.load("bunny.stl").geometry
+mesh = import_mesh("bunny.stl", m)
 boundary = PointBoundary(mesh)
 
 # Octree with uniform spacing (simple, fast)

--- a/src/WhatsThePoint.jl
+++ b/src/WhatsThePoint.jl
@@ -98,7 +98,7 @@ export repel
 include("metrics.jl")
 
 include("io.jl")
-export import_surface, visualize, save, export_vtk
+export import_mesh, import_surface, geometry_info, visualize, save, export_vtk
 
 # visualize function is defined in WhatsThePointMakieExt when Makie is loaded
 function visualize end
@@ -112,7 +112,7 @@ using PrecompileTools
 @setup_workload begin
     using Unitful: m, °
     @compile_workload begin
-        mesh = GeoIO.load(joinpath(@__DIR__, "precompile_tools_dummy.stl")).geometry
+        mesh = import_mesh(joinpath(@__DIR__, "precompile_tools_dummy.stl"), m)
         b = PointBoundary(mesh)
         split_surface!(b, 75°)
         cloud = discretize(b, ConstantSpacing(1m); alg = VanDerSandeFornberg())

--- a/src/boundary.jl
+++ b/src/boundary.jl
@@ -38,13 +38,29 @@ function PointBoundary(points)
     return PointBoundary(points, normals, areas)
 end
 
-function PointBoundary(filepath::String)
-    points, normals, areas, _ = import_surface(filepath)
+"""
+    PointBoundary(filepath, unit::Unitful.Units)
+
+Load a surface mesh and take its face centers as boundary points. The file's
+raw coordinates are reinterpreted in `unit` (see [`import_mesh`](@ref)); run
+[`geometry_info`](@ref) first when unsure which unit the file was exported in.
+"""
+function PointBoundary(filepath::AbstractString, unit::Unitful.Units)
+    points, normals, areas, _ = import_surface(filepath, unit)
     surf = PointSurface(points, normals, areas)
     M = manifold(surf)
     C = crs(surf)
     surfaces = LittleDict{Symbol, PointSurface{M, C}}(:surface1 => surf)
     return PointBoundary(surfaces)
+end
+
+# Breaking-change guard: a bare path would otherwise fall into the generic
+# PointBoundary(points) method and fail deep inside compute_normals.
+function PointBoundary(::AbstractString)
+    throw(ArgumentError(
+        "PointBoundary(filepath) now requires a unit, e.g. PointBoundary(filepath, u\"mm\"). " *
+            "Mesh files carry no unit metadata — run geometry_info(filepath) to inspect the raw extents.",
+    ))
 end
 
 """

--- a/src/cloud.jl
+++ b/src/cloud.jl
@@ -23,7 +23,7 @@ function PointCloud(boundary::PointBoundary{M, C}) where {M, C}
     return PointCloud(deepcopy(boundary), vol, NoTopology())
 end
 
-PointCloud(filepath::String) = PointCloud(PointBoundary(filepath))
+PointCloud(filepath::AbstractString, unit::Unitful.Units) = PointCloud(PointBoundary(filepath, unit))
 
 """
     PointCloud(boundary::PointBoundary{M,C1}, volume::PointVolume{M,C2}, topo)

--- a/src/discretization/algorithms/octree.jl
+++ b/src/discretization/algorithms/octree.jl
@@ -191,8 +191,6 @@ function Octree(
     )
 end
 
-Octree(filepath::String; kwargs...) = Octree(GeoIO.load(filepath).geometry; kwargs...)
-
 # ============================================================================
 # Helper functions
 # ============================================================================

--- a/src/discretization/algorithms/slak_kosec.jl
+++ b/src/discretization/algorithms/slak_kosec.jl
@@ -29,7 +29,7 @@ SlakKosec(20, octree)                # Custom n with octree acceleration
 using WhatsThePoint
 
 # Load boundary
-boundary = PointBoundary("model.stl")
+boundary = PointBoundary("model.stl", u"m")
 cloud = PointCloud(boundary)
 
 # Discretize without octree (slow for large domains)
@@ -41,16 +41,11 @@ result = discretize(cloud, spacing; alg=SlakKosec(), max_points=10_000)
 ```julia
 using WhatsThePoint
 
-# Load boundary points
-boundary = PointBoundary("model.stl")
+# Load the mesh once; boundary and octree share it
+mesh = import_mesh("model.stl", u"m")
+boundary = PointBoundary(mesh)
 cloud = PointCloud(boundary)
-
-# Build octree from STL file (Option 1: simplest)
-octree = TriangleOctree("model.stl"; min_ratio=1e-6, classify_leaves=true)
-
-# Or from SimpleMesh (Option 2)
-# mesh = GeoIO.load("model.stl").geometry
-# octree = TriangleOctree(mesh; min_ratio=1e-6, classify_leaves=true)
+octree = TriangleOctree(mesh; min_ratio=1e-6, classify_leaves=true)
 
 # Use octree-accelerated discretization (100-1000× faster!)
 spacing = ConstantSpacing(1.0u"m")

--- a/src/discretization/discretization.jl
+++ b/src/discretization/discretization.jl
@@ -23,7 +23,7 @@ Generate volume points for the given boundary and return a new PointCloud.
 
 # Example
 ```julia
-mesh = GeoIO.load("model.stl").geometry
+mesh = import_mesh("model.stl", u"m")
 boundary = PointBoundary(mesh)
 octree = TriangleOctree(mesh; min_ratio=1e-6)
 cloud = discretize(boundary, 3.0m; alg=SlakKosec(octree), max_points=100_000)

--- a/src/discretization/spacing_guidance.jl
+++ b/src/discretization/spacing_guidance.jl
@@ -15,7 +15,7 @@
 """
     suggest_spacing(mesh; n_points=nothing, bridson_factor=0.75, verbose=true)
     suggest_spacing(boundary; ...)
-    suggest_spacing("model.stl"; ...)
+    suggest_spacing("model.stl", u"mm"; ...)
 
 Quick geometry probe that recommends a baseline node spacing — the "step 0"
 before [`discretize`](@ref). Reports the domain extent, enclosed volume, and
@@ -42,8 +42,9 @@ Returns a `NamedTuple` with `extent`, `min_extent`, `max_extent`, `diagonal`,
 
 # Example
 ```julia
-g = suggest_spacing("bunny.stl")
-cloud = discretize(PointBoundary("bunny.stl"), g.h_baseline; alg=Octree("bunny.stl"))
+mesh = import_mesh("bunny.stl", u"m")
+g = suggest_spacing(mesh)
+cloud = discretize(PointBoundary(mesh), g.h_baseline; alg=Octree(mesh))
 ```
 """
 function suggest_spacing(
@@ -91,8 +92,11 @@ function suggest_spacing(
     )
 end
 
-function suggest_spacing(path::AbstractString; name::AbstractString = basename(path), kwargs...)
-    return suggest_spacing(GeoIO.load(path).geometry; name, kwargs...)
+function suggest_spacing(
+        path::AbstractString, unit::Unitful.Units;
+        name::AbstractString = basename(path), kwargs...,
+    )
+    return suggest_spacing(import_mesh(path, unit); name, kwargs...)
 end
 
 # Core recommendation math, shared by all entry points. `ext`/`V` are stripped

--- a/src/io.jl
+++ b/src/io.jl
@@ -1,12 +1,48 @@
+# Mesh files carry no unit metadata and GeoIO assigns meters by default, so the
+# stored numbers are reinterpreted in the user-supplied unit (46 -> 46 mm, no
+# conversion). Raw coordinates never change — downstream numerics are label-blind.
+function _reinterpret_unit(mesh::SimpleMesh, unit::Unitful.Units)
+    dimension(unit) == u"𝐋" || throw(ArgumentError("unit must be a length unit, got $unit"))
+    C = crs(mesh)
+    C <: Cartesian || throw(ArgumentError("unit reinterpretation requires Cartesian coordinates, got $C"))
+    verts = map(Meshes.vertices(mesh)) do p
+        Point((CoordRefSystems.raw(coords(p)) .* unit)...)
+    end
+    return SimpleMesh(verts, Meshes.topology(mesh))
+end
+
 """
-    import_surface(filepath::String)
+    import_mesh(filepath, unit::Unitful.Units) -> SimpleMesh
+
+Load a surface mesh from a file (STL, OBJ, or any format supported by GeoIO.jl)
+and *reinterpret* its raw coordinates in `unit`: a stored `46` becomes `46 mm`
+with `unit = u"mm"` — no conversion happens, because mesh files carry no unit
+metadata (GeoIO's default of meters is discarded). Topology and coordinate
+machine type (`Float32` stays `Float32`) are preserved.
+
+This is the single gateway for file geometry: the returned mesh feeds
+[`PointBoundary`](@ref), [`TriangleOctree`](@ref), and [`Octree`](@ref).
+Use [`geometry_info`](@ref) to probe the raw extents when unsure of the unit.
+"""
+function import_mesh(filepath::AbstractString, unit::Unitful.Units)
+    geom = GeoIO.load(filepath).geometry
+    geom isa SimpleMesh ||
+        throw(ArgumentError("$filepath did not load as a SimpleMesh, got $(nameof(typeof(geom)))"))
+    return _reinterpret_unit(geom, unit)
+end
+
+"""
+    import_surface(filepath, unit::Unitful.Units)
 
 Load a surface mesh from a file (STL, OBJ, or any format supported by GeoIO.jl). Returns a
-tuple of `(points, normals, areas, mesh)` where points are face centers.
+tuple of `(points, normals, areas, mesh)` where points are face centers. Coordinates are
+reinterpreted in `unit` (see [`import_mesh`](@ref)); areas therefore carry `unit^2`.
 """
-function import_surface(filepath::String)
+function import_surface(filepath::AbstractString, unit::Unitful.Units)
     geo = GeoIO.load(filepath)
-    mesh = geo.geometry
+    geo.geometry isa SimpleMesh ||
+        throw(ArgumentError("$filepath did not load as a SimpleMesh, got $(nameof(typeof(geo.geometry)))"))
+    mesh = _reinterpret_unit(geo.geometry, unit)
     points = map(centroid, elements(mesh))
     n = if hasproperty(geo, :normal)
         geo.normal
@@ -191,4 +227,60 @@ _hcat_data(data::AbstractVector) = reduce(hcat, data)
 
 function savevtk!(vtkfile)
     return vtk_save(vtkfile)
+end
+
+function _print_geometry_entry(name, bmin, bmax, ext)
+    rnd(t) = round.(t; sigdigits = 4)
+    println("─── $name ───")
+    println("  min:    $(rnd(bmin))")
+    println("  max:    $(rnd(bmax))")
+    println("  extent: $(rnd(ext))")
+    return nothing
+end
+
+"""
+    geometry_info(filepath, filepaths...; verbose=true) -> Vector{NamedTuple}
+
+Inspect the raw bounding box of one or more mesh files before constructing
+anything — the "what do these numbers mean?" probe for files without unit
+metadata (STL coordinates are just numbers; GeoIO.jl assigns meters by
+default). Returns one `(file, min, max, extent)` named tuple per file, with
+values as raw (unitless) coordinate tuples. With `verbose=true` prints each
+bounding box and, for multiple files, their union — useful when parts must fit
+together.
+
+Once you know the unit, pass it to [`import_mesh`](@ref) or
+[`PointBoundary`](@ref) — the raw numbers are reinterpreted in that unit.
+
+# Example
+```julia
+geometry_info("intake.stl", "exhaust.stl")
+# ─── intake.stl ───
+#   min:    (0.0, 0.0, 0.0)
+#   max:    (120.5, 87.3, 42.0)
+#   extent: (120.5, 87.3, 42.0)
+# ─── exhaust.stl ───
+#   ...
+# ─── Union ───
+#   ...
+```
+"""
+function geometry_info(filepath::AbstractString, filepaths::AbstractString...; verbose::Bool = true)
+    entries = map((filepath, filepaths...)) do f
+        box = boundingbox(Meshes.vertices(GeoIO.load(f).geometry))
+        bmin = Tuple(ustrip.(to(minimum(box))))
+        bmax = Tuple(ustrip.(to(maximum(box))))
+        (file = f, min = bmin, max = bmax, extent = bmax .- bmin)
+    end
+    if verbose
+        for e in entries
+            _print_geometry_entry(basename(e.file), e.min, e.max, e.extent)
+        end
+        if length(entries) > 1
+            umin = reduce((a, b) -> min.(a, b), (e.min for e in entries))
+            umax = reduce((a, b) -> max.(a, b), (e.max for e in entries))
+            _print_geometry_entry("Union", umin, umax, umax .- umin)
+        end
+    end
+    return collect(entries)
 end

--- a/src/octree/triangle_octree.jl
+++ b/src/octree/triangle_octree.jl
@@ -382,11 +382,6 @@ function TriangleOctree(
     )
 end
 
-function TriangleOctree(filepath::String; kwargs...)
-    geo = GeoIO.load(filepath)
-    return TriangleOctree(geo.geometry; kwargs...)
-end
-
 function _subdivide_triangle_octree!(
         tree::SpatialOctree{Int, T},
         mesh::SimpleMesh,

--- a/src/surface.jl
+++ b/src/surface.jl
@@ -84,8 +84,8 @@ function PointSurface(points::AbstractVector; k::Int = 5, topology = NoTopology(
     return surf
 end
 
-function PointSurface(filepath::String; topology = NoTopology())
-    points, normals, areas, _ = import_surface(filepath)
+function PointSurface(filepath::AbstractString, unit::Unitful.Units; topology = NoTopology())
+    points, normals, areas, _ = import_surface(filepath, unit)
     return PointSurface(points, normals, areas; topology = topology)
 end
 

--- a/test/boundary.jl
+++ b/test/boundary.jl
@@ -7,7 +7,7 @@
 end
 
 @testitem "PointBoundary from file" setup = [TestData, CommonImports] begin
-    b = PointBoundary(TestData.BIFURCATION_PATH)
+    b = PointBoundary(TestData.BIFURCATION_PATH, u"m")
     @test length(b) == 24780
     @test hassurface(b, :surface1)
 end

--- a/test/cloud.jl
+++ b/test/cloud.jl
@@ -7,13 +7,13 @@
 end
 
 @testitem "PointCloud from file" setup = [TestData, CommonImports] begin
-    cloud = PointCloud(TestData.BIFURCATION_PATH)
+    cloud = PointCloud(TestData.BIFURCATION_PATH, u"m")
     @test length(cloud) == 24780
     @test hassurface(cloud, :surface1)
 end
 
 @testitem "PointCloud from PointBoundary file" setup = [TestData, CommonImports] begin
-    cloud = PointCloud(PointBoundary(TestData.BIFURCATION_PATH))
+    cloud = PointCloud(PointBoundary(TestData.BIFURCATION_PATH, u"m"))
     @test length(cloud) == 24780
     @test hassurface(cloud, :surface1)
 end

--- a/test/discretization.jl
+++ b/test/discretization.jl
@@ -19,8 +19,8 @@ end
 end
 
 @testitem "SlakKosec with octree" setup = [TestData, CommonImports] begin
-    bnd = PointBoundary(TestData.BOX_PATH)
-    octree = TriangleOctree(TestData.BOX_PATH; classify_leaves = true)
+    bnd = PointBoundary(TestData.BOX_PATH, u"m")
+    octree = TriangleOctree(import_mesh(TestData.BOX_PATH, u"m"); classify_leaves = true)
     spacing = _relative_spacing(bnd)
 
     cloud = discretize(bnd, spacing; alg = SlakKosec(octree), max_points = 50)
@@ -37,7 +37,7 @@ end
 @testitem "VanDerSandeFornberg" setup = [TestData, CommonImports] begin
     @test_skip "Temporarily skipped - slow without octree acceleration"
 
-    bnd = PointBoundary(TestData.BOX_PATH)
+    bnd = PointBoundary(TestData.BOX_PATH, u"m")
     spacing = _relative_spacing(bnd)
 
     cloud = discretize(bnd, spacing; alg = VanDerSandeFornberg(), max_points = 50)
@@ -72,8 +72,8 @@ end
 end
 
 @testitem "max_points cap" setup = [TestData, CommonImports] begin
-    bnd = PointBoundary(TestData.BOX_PATH)
-    octree = TriangleOctree(TestData.BOX_PATH; classify_leaves = true)
+    bnd = PointBoundary(TestData.BOX_PATH, u"m")
+    octree = TriangleOctree(import_mesh(TestData.BOX_PATH, u"m"); classify_leaves = true)
     spacing = _relative_spacing(bnd)
 
     cloud = discretize(bnd, spacing; alg = SlakKosec(octree), max_points = 20)
@@ -82,8 +82,8 @@ end
 
 @testitem "discretize accepts bare Unitful.Length" setup = [TestData, CommonImports] begin
     # Test convenience overload that wraps bare Length in ConstantSpacing
-    bnd = PointBoundary(TestData.BOX_PATH)
-    octree = TriangleOctree(TestData.BOX_PATH; classify_leaves = true)
+    bnd = PointBoundary(TestData.BOX_PATH, u"m")
+    octree = TriangleOctree(import_mesh(TestData.BOX_PATH, u"m"); classify_leaves = true)
 
     # Should accept 3.0m instead of ConstantSpacing(3.0m)
     cloud = discretize(bnd, 3.0m; alg = SlakKosec(octree), max_points = 30)
@@ -94,10 +94,10 @@ end
 
 @testitem "discretize works with PointCloud input" setup = [TestData, CommonImports] begin
     # Test discretize(cloud::PointCloud, ...) overload
-    bnd = PointBoundary(TestData.BOX_PATH)
+    bnd = PointBoundary(TestData.BOX_PATH, u"m")
     cloud = PointCloud(bnd)  # Empty volume
 
-    octree = TriangleOctree(TestData.BOX_PATH; classify_leaves = true)
+    octree = TriangleOctree(import_mesh(TestData.BOX_PATH, u"m"); classify_leaves = true)
     spacing = _relative_spacing(bnd)
 
     # Discretize the empty cloud
@@ -114,7 +114,7 @@ end
 
 @testitem "SlakKosec with BoundaryLayerSpacing" setup = [TestData, CommonImports] begin
     # Test SlakKosec with variable spacing (exercises calculate_ninit for VariableSpacing)
-    bnd = PointBoundary(TestData.BOX_PATH)
+    bnd = PointBoundary(TestData.BOX_PATH, u"m")
     spacing = BoundaryLayerSpacing(
         WhatsThePoint.points(bnd);
         at_wall = 0.5m,
@@ -122,7 +122,7 @@ end
         layer_thickness = 2.0m
     )
 
-    octree = TriangleOctree(TestData.BOX_PATH; classify_leaves = true)
+    octree = TriangleOctree(import_mesh(TestData.BOX_PATH, u"m"); classify_leaves = true)
     cloud = discretize(bnd, spacing; alg = SlakKosec(octree), max_points = 30)
     @test cloud isa PointCloud
     @test length(volume(cloud)) > 0
@@ -131,8 +131,8 @@ end
 
 @testitem "SlakKosec with variable spacing exercises calculate_ninit" setup = [TestData, CommonImports] begin
     # Test SlakKosec with variable spacing to exercise calculate_ninit(::VariableSpacing)
-    bnd = PointBoundary(TestData.BOX_PATH)
-    octree = TriangleOctree(TestData.BOX_PATH; classify_leaves = true)
+    bnd = PointBoundary(TestData.BOX_PATH, u"m")
+    octree = TriangleOctree(import_mesh(TestData.BOX_PATH, u"m"); classify_leaves = true)
     spacing = BoundaryLayerSpacing(
         WhatsThePoint.points(bnd);
         at_wall = 0.8m,
@@ -169,7 +169,7 @@ end
 
 @testitem "BoundaryLayerSpacing validation" setup = [TestData, CommonImports] begin
     # Test that BoundaryLayerSpacing validates layer_thickness > 0
-    bnd = PointBoundary(TestData.BOX_PATH)
+    bnd = PointBoundary(TestData.BOX_PATH, u"m")
 
     @test_throws ArgumentError BoundaryLayerSpacing(
         WhatsThePoint.points(bnd);

--- a/test/io.jl
+++ b/test/io.jl
@@ -1,6 +1,6 @@
 @testitem "import_surface" setup = [TestData, CommonImports] begin
     filepath = TestData.BOX_PATH
-    points, normals, areas, mesh = import_surface(filepath)
+    points, normals, areas, mesh = import_surface(filepath, u"m")
 
     @test points isa Vector{<:Point}
     @test length(points) > 0
@@ -16,7 +16,7 @@
 end
 
 @testitem "save VTK cloud" setup = [TestData, CommonImports] begin
-    boundary = PointBoundary(TestData.BOX_PATH)
+    boundary = PointBoundary(TestData.BOX_PATH, u"m")
     cloud = PointCloud(boundary)
 
     mktempdir() do tmpdir
@@ -31,7 +31,7 @@ end
     using StaticArrays: SVector
     using Unitful: Pa
 
-    boundary = PointBoundary(TestData.BOX_PATH)
+    boundary = PointBoundary(TestData.BOX_PATH, u"m")
     cloud = PointCloud(boundary)
     n = length(cloud)
 
@@ -79,7 +79,7 @@ end
 end
 
 @testitem "save VTK boundary" setup = [TestData, CommonImports] begin
-    boundary = PointBoundary(TestData.BOX_PATH)
+    boundary = PointBoundary(TestData.BOX_PATH, u"m")
 
     mktempdir() do tmpdir
         filename = joinpath(tmpdir, "test_boundary")
@@ -90,7 +90,7 @@ end
 end
 
 @testitem "save VTK surface" setup = [TestData, CommonImports] begin
-    boundary = PointBoundary(TestData.BOX_PATH)
+    boundary = PointBoundary(TestData.BOX_PATH, u"m")
     surf = boundary[:surface1]
 
     mktempdir() do tmpdir
@@ -121,7 +121,7 @@ end
 
 @testitem "IO Round-trip" setup = [TestData, CommonImports] begin
     mktempdir() do tmpdir
-        boundary = PointBoundary(TestData.BOX_PATH)
+        boundary = PointBoundary(TestData.BOX_PATH, u"m")
 
         cloud = PointCloud(boundary)
         original_length = length(cloud)
@@ -141,4 +141,75 @@ end
         @test length(loaded_cloud) == original_length
         @test hassurface(loaded_cloud, :surface1)
     end
+end
+
+@testitem "geometry_info reports raw bounding boxes" setup = [CommonImports, TestData] begin
+    info = geometry_info(TestData.BOX_PATH; verbose = false)
+    @test length(info) == 1
+    @test info[1].file == TestData.BOX_PATH
+    @test info[1].extent == info[1].max .- info[1].min
+    ref = boundingbox(Meshes.vertices(GeoIO.load(TestData.BOX_PATH).geometry))
+    @test info[1].min == Tuple(ustrip.(to(minimum(ref))))
+    @test info[1].max == Tuple(ustrip.(to(maximum(ref))))
+
+    info2 = geometry_info(TestData.BOX_PATH, TestData.BIFURCATION_PATH; verbose = false)
+    @test length(info2) == 2
+    @test info2[2].file == TestData.BIFURCATION_PATH
+
+    old_stdout = stdout
+    rd, wr = redirect_stdout()
+    geometry_info(TestData.BOX_PATH)
+    redirect_stdout(old_stdout)
+    close(wr)
+    single = read(rd, String)
+    close(rd)
+    @test occursin("box.stl", single)
+    @test occursin("extent:", single)
+    @test !occursin("Union", single)
+
+    old_stdout = stdout
+    rd, wr = redirect_stdout()
+    geometry_info(TestData.BOX_PATH, TestData.BIFURCATION_PATH)
+    redirect_stdout(old_stdout)
+    close(wr)
+    multi = read(rd, String)
+    close(rd)
+    @test occursin("box.stl", multi)
+    @test occursin("bifurcation.stl", multi)
+    @test occursin("Union", multi)
+end
+
+@testitem "import_mesh reinterprets units without conversion" setup = [CommonImports, TestData] begin
+    r = import_mesh(TestData.BOX_PATH, u"mm")
+    @test r isa SimpleMesh
+    @test unit(to(first(Meshes.vertices(r)))[1]) == u"mm"
+
+    # raw numbers unchanged — reinterpretation, not conversion
+    info = geometry_info(TestData.BOX_PATH; verbose = false)
+    box = boundingbox(Meshes.vertices(r))
+    @test Tuple(ustrip.(to(minimum(box)))) == info[1].min
+    @test Tuple(ustrip.(to(maximum(box)))) == info[1].max
+
+    @test PointBoundary(r) isa PointBoundary
+    @test TriangleOctree(r) isa TriangleOctree
+
+    @test_throws ArgumentError import_mesh(TestData.BOX_PATH, u"s")
+    # unit is now required on every path-taking entry point
+    @test_throws ArgumentError PointBoundary(TestData.BOX_PATH)
+end
+
+@testitem "unit reinterpretation preserves topology and mactype" setup = [CommonImports, OctreeTestData] begin
+    cube = OctreeTestData.unit_cube_mesh()
+    r = WhatsThePoint._reinterpret_unit(cube, u"mm")
+    @test Meshes.topology(r) === Meshes.topology(cube)
+    @test ustrip.(to(last(Meshes.vertices(r)))) == ustrip.(to(last(Meshes.vertices(cube))))
+    @test to(maximum(boundingbox(Meshes.vertices(r))))[1] == 1.0u"mm"
+    b = PointBoundary(r)
+    @test unit(first(area(first(surfaces(b))))) == u"mm^2"
+
+    mesh32 = OctreeTestData.unit_cube_mesh(Float32)
+    r32 = WhatsThePoint._reinterpret_unit(mesh32, u"mm")
+    @test CoordRefSystems.mactype(Meshes.crs(r32)) === Float32
+    @test ustrip(to(first(Meshes.vertices(r32)))[1]) isa Float32
+    @test CoordRefSystems.mactype(Meshes.crs(first(points(PointBoundary(r32))))) === Float32
 end

--- a/test/isinside.jl
+++ b/test/isinside.jl
@@ -59,14 +59,14 @@ end
 end
 
 @testitem "isinside 3D PointBoundary" setup = [TestData, CommonImports] begin
-    boundary = PointBoundary(TestData.BOX_PATH)
+    boundary = PointBoundary(TestData.BOX_PATH, u"m")
     @test isinside(Point(0.5, 0.5, 0.5), boundary)
     @test !isinside(Point(0.5, 0.5, -0.5), boundary)
     @test !isinside(Point(0.5, 0.5, -0.001), boundary)
 end
 
 @testitem "isinside 3D PointCloud" setup = [TestData, CommonImports] begin
-    boundary = PointBoundary(TestData.BOX_PATH)
+    boundary = PointBoundary(TestData.BOX_PATH, u"m")
     cloud = PointCloud(boundary)
 
     @test isinside(Point(12.5, 12.5, 12.5), cloud)
@@ -75,14 +75,14 @@ end
 end
 
 @testitem "isinside 3D PointSurface MethodError" setup = [TestData, CommonImports] begin
-    boundary = PointBoundary(TestData.BOX_PATH)
+    boundary = PointBoundary(TestData.BOX_PATH, u"m")
     surf = boundary[:surface1]
 
     @test_throws MethodError isinside(Point(12.5, 12.5, 12.5), surf)
 end
 
 @testitem "isinside 3D testpoint as AbstractVector" setup = [TestData, CommonImports] begin
-    boundary = PointBoundary(TestData.BOX_PATH)
+    boundary = PointBoundary(TestData.BOX_PATH, u"m")
     surf = boundary[:surface1]
 
     @test_throws MethodError isinside([0.5, 0.5, 0.5], surf)

--- a/test/metrics.jl
+++ b/test/metrics.jl
@@ -10,7 +10,7 @@
         return output, result
     end
 
-    cloud = PointCloud(TestData.BOX_PATH)
+    cloud = PointCloud(TestData.BOX_PATH, u"m")
 
     output, result = capture_stdout(() -> metrics(cloud))
 
@@ -41,7 +41,7 @@ end
         return output, result
     end
 
-    cloud = PointCloud(TestData.BOX_PATH)
+    cloud = PointCloud(TestData.BOX_PATH, u"m")
 
     output, result = capture_stdout(() -> metrics(cloud; k = 10))
 
@@ -72,7 +72,7 @@ end
         return output, result
     end
 
-    cloud = PointCloud(TestData.BOX_PATH)
+    cloud = PointCloud(TestData.BOX_PATH, u"m")
 
     output, result = capture_stdout(() -> metrics(cloud; k = 5))
 
@@ -98,7 +98,7 @@ end
         return output, result
     end
 
-    cloud = PointCloud(TestData.BOX_PATH)
+    cloud = PointCloud(TestData.BOX_PATH, u"m")
 
     output, _ = capture_stdout(() -> metrics(cloud; k = 10))
 
@@ -143,8 +143,8 @@ end
 end
 
 @testitem "spacing_metrics return shape" setup = [TestData, CommonImports] begin
-    boundary = PointBoundary(TestData.BOX_PATH)
-    octree = TriangleOctree(TestData.BOX_PATH; classify_leaves = true)
+    boundary = PointBoundary(TestData.BOX_PATH, u"m")
+    octree = TriangleOctree(import_mesh(TestData.BOX_PATH, u"m"); classify_leaves = true)
     spacing = _relative_spacing(boundary)
     cloud = discretize(boundary, spacing; alg = SlakKosec(octree), max_points = 50)
 
@@ -164,8 +164,8 @@ end
 end
 
 @testitem "spacing_metrics custom k" setup = [TestData, CommonImports] begin
-    boundary = PointBoundary(TestData.BOX_PATH)
-    octree = TriangleOctree(TestData.BOX_PATH; classify_leaves = true)
+    boundary = PointBoundary(TestData.BOX_PATH, u"m")
+    octree = TriangleOctree(import_mesh(TestData.BOX_PATH, u"m"); classify_leaves = true)
     spacing = _relative_spacing(boundary)
     cloud = discretize(boundary, spacing; alg = SlakKosec(octree), max_points = 50)
 
@@ -179,8 +179,8 @@ end
 @testitem "spacing_metrics penalizes mismatched target" setup = [TestData, CommonImports] begin
     using Unitful: m
 
-    boundary = PointBoundary(TestData.BOX_PATH)
-    octree = TriangleOctree(TestData.BOX_PATH; classify_leaves = true)
+    boundary = PointBoundary(TestData.BOX_PATH, u"m")
+    octree = TriangleOctree(import_mesh(TestData.BOX_PATH, u"m"); classify_leaves = true)
     spacing_correct = _relative_spacing(boundary)
     cloud = discretize(boundary, spacing_correct; alg = SlakKosec(octree), max_points = 50)
 
@@ -196,8 +196,8 @@ end
 end
 
 @testitem "spacing_metrics tracks repel" setup = [TestData, CommonImports] begin
-    boundary = PointBoundary(TestData.BOX_PATH)
-    octree = TriangleOctree(TestData.BOX_PATH; classify_leaves = true)
+    boundary = PointBoundary(TestData.BOX_PATH, u"m")
+    octree = TriangleOctree(import_mesh(TestData.BOX_PATH, u"m"); classify_leaves = true)
     spacing = _relative_spacing(boundary)
     cloud = discretize(boundary, spacing; alg = SlakKosec(octree), max_points = 50)
 
@@ -214,8 +214,8 @@ end
 end
 
 @testitem "spacing_fidelity_metrics" setup = [TestData, CommonImports] begin
-    boundary = PointBoundary(TestData.BOX_PATH)
-    octree = TriangleOctree(TestData.BOX_PATH; classify_leaves = true)
+    boundary = PointBoundary(TestData.BOX_PATH, u"m")
+    octree = TriangleOctree(import_mesh(TestData.BOX_PATH, u"m"); classify_leaves = true)
     spacing = _relative_spacing(boundary)
     cloud = discretize(boundary, spacing; alg = SlakKosec(octree), max_points = 50)
 

--- a/test/neighbors.jl
+++ b/test/neighbors.jl
@@ -136,7 +136,7 @@ end
 end
 
 @testitem "KNearestSearch with real geometry" setup = [TestData, CommonImports] begin
-    cloud = PointCloud(TestData.BOX_PATH)
+    cloud = PointCloud(TestData.BOX_PATH, u"m")
 
     @testset "Search on imported geometry" begin
         k = 10

--- a/test/octree.jl
+++ b/test/octree.jl
@@ -377,8 +377,8 @@ end
     @test length(WhatsThePoint.volume(cloud)) > 0
     @test alg.node_min_ratio < 1.0
 
-    # Test string filepath constructor
-    alg2 = Octree(TestData.BOX_PATH)
+    # Test construction from an imported mesh
+    alg2 = Octree(import_mesh(TestData.BOX_PATH, u"m"))
     @test alg2 isa Octree
     @test alg2.triangle_octree isa WhatsThePoint.TriangleOctree
 end
@@ -427,7 +427,7 @@ end
 
     # Non-Octree algorithms are untouched: same Float32 boundary still works
     # through SlakKosec.
-    octree = TriangleOctree(TestData.BOX_PATH; classify_leaves = true)
+    octree = TriangleOctree(import_mesh(TestData.BOX_PATH, u"m"); classify_leaves = true)
     cloud_sk = discretize(bnd, ConstantSpacing(3.0f0m); alg = SlakKosec(octree), max_points = 20)
     @test cloud_sk isa PointCloud
 end

--- a/test/octree_triangle_octree.jl
+++ b/test/octree_triangle_octree.jl
@@ -52,7 +52,7 @@ end
 
 @testitem "TriangleOctree from file" setup = [CommonImports, TestData] begin
     if isfile(TestData.BOX_PATH)
-        octree = TriangleOctree(TestData.BOX_PATH)
+        octree = TriangleOctree(import_mesh(TestData.BOX_PATH, u"m"))
         @test octree isa TriangleOctree
         @test num_triangles(octree) == 46786
     else

--- a/test/repel.jl
+++ b/test/repel.jl
@@ -1,6 +1,6 @@
 @testitem "repel convergence success" setup = [TestData, CommonImports] begin
-    boundary = PointBoundary(TestData.BOX_PATH)
-    octree = TriangleOctree(TestData.BOX_PATH; classify_leaves = true)
+    boundary = PointBoundary(TestData.BOX_PATH, u"m")
+    octree = TriangleOctree(import_mesh(TestData.BOX_PATH, u"m"); classify_leaves = true)
     spacing = _relative_spacing(boundary)
     cloud = discretize(boundary, spacing; alg = SlakKosec(octree), max_points = 20)
 
@@ -13,8 +13,8 @@
 end
 
 @testitem "repel basic behavior" setup = [TestData, CommonImports] begin
-    boundary = PointBoundary(TestData.BOX_PATH)
-    octree = TriangleOctree(TestData.BOX_PATH; classify_leaves = true)
+    boundary = PointBoundary(TestData.BOX_PATH, u"m")
+    octree = TriangleOctree(import_mesh(TestData.BOX_PATH, u"m"); classify_leaves = true)
     spacing = _relative_spacing(boundary)
     cloud = discretize(boundary, spacing; alg = SlakKosec(octree), max_points = 50)
 
@@ -41,8 +41,8 @@ end
 end
 
 @testitem "repel respects max_iters" setup = [TestData, CommonImports] begin
-    boundary = PointBoundary(TestData.BOX_PATH)
-    octree = TriangleOctree(TestData.BOX_PATH; classify_leaves = true)
+    boundary = PointBoundary(TestData.BOX_PATH, u"m")
+    octree = TriangleOctree(import_mesh(TestData.BOX_PATH, u"m"); classify_leaves = true)
     spacing = _relative_spacing(boundary)
 
     conv1 = Float64[]
@@ -57,8 +57,8 @@ end
 end
 
 @testitem "repel accepts parameter combinations" setup = [TestData, CommonImports] begin
-    boundary = PointBoundary(TestData.BOX_PATH)
-    octree = TriangleOctree(TestData.BOX_PATH; classify_leaves = true)
+    boundary = PointBoundary(TestData.BOX_PATH, u"m")
+    octree = TriangleOctree(import_mesh(TestData.BOX_PATH, u"m"); classify_leaves = true)
     spacing = _relative_spacing(boundary)
     cloud = discretize(boundary, spacing; alg = SlakKosec(octree), max_points = 30)
 
@@ -73,8 +73,8 @@ end
 end
 
 @testitem "repel boundary projection preserves points" setup = [TestData, CommonImports] begin
-    boundary = PointBoundary(TestData.BOX_PATH)
-    octree = TriangleOctree(TestData.BOX_PATH; classify_leaves = true)
+    boundary = PointBoundary(TestData.BOX_PATH, u"m")
+    octree = TriangleOctree(import_mesh(TestData.BOX_PATH, u"m"); classify_leaves = true)
     spacing = _relative_spacing(boundary)
     cloud = discretize(boundary, spacing; alg = SlakKosec(octree), max_points = 50)
 
@@ -102,8 +102,8 @@ end
 end
 
 @testitem "repel without octree" setup = [TestData, CommonImports] begin
-    boundary = PointBoundary(TestData.BOX_PATH)
-    octree = TriangleOctree(TestData.BOX_PATH; classify_leaves = true)
+    boundary = PointBoundary(TestData.BOX_PATH, u"m")
+    octree = TriangleOctree(import_mesh(TestData.BOX_PATH, u"m"); classify_leaves = true)
     spacing = _relative_spacing(boundary)
     cloud = discretize(boundary, spacing; alg = SlakKosec(octree), max_points = 50)
 
@@ -185,8 +185,8 @@ end
 @testitem "repel β kwarg feeds default force_model" setup = [TestData, CommonImports] begin
     # The β kwarg must continue to affect the default ClippedSpacingForce so that
     # existing callers that pass `β=...` keep working without passing force_model.
-    boundary = PointBoundary(TestData.BOX_PATH)
-    octree = TriangleOctree(TestData.BOX_PATH; classify_leaves = true)
+    boundary = PointBoundary(TestData.BOX_PATH, u"m")
+    octree = TriangleOctree(import_mesh(TestData.BOX_PATH, u"m"); classify_leaves = true)
     spacing = _relative_spacing(boundary)
     cloud = discretize(boundary, spacing; alg = SlakKosec(octree), max_points = 30)
 
@@ -208,8 +208,8 @@ end
 end
 
 @testitem "repel accepts SpacingEquilibriumForce" setup = [TestData, CommonImports] begin
-    boundary = PointBoundary(TestData.BOX_PATH)
-    octree = TriangleOctree(TestData.BOX_PATH; classify_leaves = true)
+    boundary = PointBoundary(TestData.BOX_PATH, u"m")
+    octree = TriangleOctree(import_mesh(TestData.BOX_PATH, u"m"); classify_leaves = true)
     spacing = _relative_spacing(boundary)
     cloud = discretize(boundary, spacing; alg = SlakKosec(octree), max_points = 50)
 
@@ -233,8 +233,8 @@ end
 @testitem "repel force models both reduce spacing error" setup = [TestData, CommonImports] begin
     using WhatsThePoint: spacing_metrics
 
-    boundary = PointBoundary(TestData.BOX_PATH)
-    octree = TriangleOctree(TestData.BOX_PATH; classify_leaves = true)
+    boundary = PointBoundary(TestData.BOX_PATH, u"m")
+    octree = TriangleOctree(import_mesh(TestData.BOX_PATH, u"m"); classify_leaves = true)
     spacing = _relative_spacing(boundary; divisor = 4)
     cloud = discretize(boundary, spacing; alg = SlakKosec(octree), max_points = 80)
 
@@ -260,8 +260,8 @@ end
 end
 
 @testitem "repel stall_after stops on quality plateau" setup = [TestData, CommonImports] begin
-    boundary = PointBoundary(TestData.BOX_PATH)
-    octree = TriangleOctree(TestData.BOX_PATH; classify_leaves = true)
+    boundary = PointBoundary(TestData.BOX_PATH, u"m")
+    octree = TriangleOctree(import_mesh(TestData.BOX_PATH, u"m"); classify_leaves = true)
     spacing = _relative_spacing(boundary)
     cloud = discretize(boundary, spacing; alg = SlakKosec(octree), max_points = 50)
 
@@ -325,8 +325,8 @@ end
 end
 
 @testitem "repel deposit_ratio grows the boundary from escaped points" setup = [TestData, CommonImports] begin
-    octree = TriangleOctree(TestData.BOX_PATH; classify_leaves = true)
-    full = PointBoundary(TestData.BOX_PATH)
+    octree = TriangleOctree(import_mesh(TestData.BOX_PATH, u"m"); classify_leaves = true)
+    full = PointBoundary(TestData.BOX_PATH, u"m")
     # Deliberately sparse boundary: deposition must grow the surface population
     # until it can contain the interior at the prescribed density.
     ids = 1:200:length(full)
@@ -373,8 +373,8 @@ end
 end
 
 @testitem "repel cull_ratio enforces the separation guarantee" setup = [TestData, CommonImports] begin
-    boundary = PointBoundary(TestData.BOX_PATH)
-    octree = TriangleOctree(TestData.BOX_PATH; classify_leaves = true)
+    boundary = PointBoundary(TestData.BOX_PATH, u"m")
+    octree = TriangleOctree(import_mesh(TestData.BOX_PATH, u"m"); classify_leaves = true)
     # Spacing must be consistent with the boundary tessellation: box.stl's face
     # centers sit ~0.22 m apart, while bbox/8 ≈ 5.4 m would put the 0.5·h cull
     # radius across ~12 boundary spacings — asking the cull to decimate the
@@ -397,8 +397,8 @@ end
 end
 
 @testitem "repel kick_after breaks frozen standoffs" setup = [TestData, CommonImports] begin
-    boundary = PointBoundary(TestData.BOX_PATH)
-    octree = TriangleOctree(TestData.BOX_PATH; classify_leaves = true)
+    boundary = PointBoundary(TestData.BOX_PATH, u"m")
+    octree = TriangleOctree(import_mesh(TestData.BOX_PATH, u"m"); classify_leaves = true)
     spacing = _relative_spacing(boundary)
     cloud = discretize(boundary, spacing; alg = SlakKosec(octree), max_points = 30)
 
@@ -432,8 +432,8 @@ end
 end
 
 @testitem "repel trace records closest pair" setup = [TestData, CommonImports] begin
-    boundary = PointBoundary(TestData.BOX_PATH)
-    octree = TriangleOctree(TestData.BOX_PATH; classify_leaves = true)
+    boundary = PointBoundary(TestData.BOX_PATH, u"m")
+    octree = TriangleOctree(import_mesh(TestData.BOX_PATH, u"m"); classify_leaves = true)
     spacing = _relative_spacing(boundary)
     cloud = discretize(boundary, spacing; alg = SlakKosec(octree), max_points = 30)
 
@@ -450,8 +450,8 @@ end
 end
 
 @testitem "repel rebuild_every skips k-NN rebuild" setup = [TestData, CommonImports] begin
-    boundary = PointBoundary(TestData.BOX_PATH)
-    octree = TriangleOctree(TestData.BOX_PATH; classify_leaves = true)
+    boundary = PointBoundary(TestData.BOX_PATH, u"m")
+    octree = TriangleOctree(import_mesh(TestData.BOX_PATH, u"m"); classify_leaves = true)
     spacing = _relative_spacing(boundary)
     cloud = discretize(boundary, spacing; alg = SlakKosec(octree), max_points = 30)
 

--- a/test/spacing_guidance.jl
+++ b/test/spacing_guidance.jl
@@ -43,7 +43,7 @@ end
     using Unitful: ustrip
     import GeoIO
 
-    g_path = suggest_spacing(TestData.BOX_PATH; verbose = false)
+    g_path = suggest_spacing(TestData.BOX_PATH, u"m"; verbose = false)
     @test ustrip(g_path.h_ceiling) > 0
     @test g_path.n_triangles > 0
 

--- a/test/surface.jl
+++ b/test/surface.jl
@@ -18,7 +18,7 @@
     @test length(surf) == 10
     @test surf.geoms isa StructVector
 
-    surf = PointSurface(TestData.BIFURCATION_PATH)
+    surf = PointSurface(TestData.BIFURCATION_PATH, u"m")
     @test length(surf) == 24780
     @test surf.geoms isa StructVector
 
@@ -106,7 +106,7 @@ end
 end
 
 @testitem "PointSurface Shadow Generation" setup = [TestData, CommonImports] begin
-    surf_file = PointSurface(TestData.BIFURCATION_PATH)
+    surf_file = PointSurface(TestData.BIFURCATION_PATH, u"m")
     shadow = ShadowPoints(2m)
 
     shadow_points = generate_shadows(surf_file, shadow)
@@ -115,7 +115,7 @@ end
 end
 
 @testitem "PointSurface Surface Operations" setup = [TestData, CommonImports] begin
-    boundary = PointBoundary(TestData.BIFURCATION_PATH)
+    boundary = PointBoundary(TestData.BIFURCATION_PATH, u"m")
     split_surface!(boundary, 80°)
     @test length(namedsurfaces(boundary)) == 4
 end

--- a/test/surface_operations.jl
+++ b/test/surface_operations.jl
@@ -67,7 +67,7 @@ end
 end
 
 @testitem "split_surface! - single surface" setup = [TestData, CommonImports] begin
-    boundary = PointBoundary(TestData.BIFURCATION_PATH)
+    boundary = PointBoundary(TestData.BIFURCATION_PATH, u"m")
     @test length(namedsurfaces(boundary)) == 1
 
     split_surface!(boundary, 80°)
@@ -78,7 +78,7 @@ end
 end
 
 @testitem "split_surface! - by target surface name" setup = [TestData, CommonImports] begin
-    boundary = PointBoundary(TestData.BIFURCATION_PATH)
+    boundary = PointBoundary(TestData.BIFURCATION_PATH, u"m")
 
     split_surface!(boundary, :surface1, 80°)
 
@@ -88,7 +88,7 @@ end
 end
 
 @testitem "split_surface! - by PointSurface object" setup = [TestData, CommonImports] begin
-    boundary = PointBoundary(TestData.BIFURCATION_PATH)
+    boundary = PointBoundary(TestData.BIFURCATION_PATH, u"m")
     surf = boundary[:surface1]
     original_length = length(boundary)
 
@@ -103,7 +103,7 @@ end
 
 @testitem "split_surface! - with PointCloud" setup = [TestData, CommonImports] begin
     using WhatsThePoint: boundary
-    cloud = PointCloud(TestData.BIFURCATION_PATH)
+    cloud = PointCloud(TestData.BIFURCATION_PATH, u"m")
     @test length(namedsurfaces(cloud)) == 1
 
     split_surface!(cloud, 80°)
@@ -130,8 +130,8 @@ end
 end
 
 @testitem "split_surface! - different angles" setup = [TestData, CommonImports] begin
-    boundary1 = PointBoundary(TestData.BIFURCATION_PATH)
-    boundary2 = PointBoundary(TestData.BIFURCATION_PATH)
+    boundary1 = PointBoundary(TestData.BIFURCATION_PATH, u"m")
+    boundary2 = PointBoundary(TestData.BIFURCATION_PATH, u"m")
 
     split_surface!(boundary1, 45°)
     split_surface!(boundary2, 60°)
@@ -144,14 +144,14 @@ end
 end
 
 @testitem "split_surface! - custom k parameter" setup = [TestData, CommonImports] begin
-    boundary = PointBoundary(TestData.BIFURCATION_PATH)
+    boundary = PointBoundary(TestData.BIFURCATION_PATH, u"m")
 
     @test_nowarn split_surface!(boundary, 80°; k = 15)
     @test length(namedsurfaces(boundary)) > 1
 end
 
 @testitem "surface operations integration" setup = [TestData, CommonImports] begin
-    boundary = PointBoundary(TestData.BIFURCATION_PATH)
+    boundary = PointBoundary(TestData.BIFURCATION_PATH, u"m")
     original_length = length(boundary)
 
     split_surface!(boundary, 80°)


### PR DESCRIPTION
Fixes #64

Mesh files carry no unit metadata, and GeoIO.jl silently stamps **meters** on every file it loads — often wrong for CAD parts exported in mm or inches. Instead of patching units after the fact, this makes the unit decision **required at import**: the only way file geometry enters the package is with an explicit statement of what its numbers mean.

## New API

```julia
info  = geometry_info("part.stl")        # unitless probe: "these numbers look like mm"
mesh  = import_mesh("part.stl", u"mm")   # THE gateway — unit required, stated once
bnd   = PointBoundary(mesh)              # or PointBoundary(mesh, spacing)
oct   = TriangleOctree(mesh; classify_leaves=true)
cloud = discretize(bnd, sp; alg=Octree(mesh))

bnd   = PointBoundary("part.stl", u"mm") # convenience for mesh-free workflows
```

- **`import_mesh(filepath, unit)`** — loads and *reinterprets* the raw coordinates in `unit` (a stored `46` becomes `46 mm`, not a conversion). Topology and machine type are preserved (binary STL stays Float32).
- **`geometry_info(filepath...)`** — lightweight raw-bbox probe (per-file min/max/extent + union bbox for multiple files) used to decide the unit.

## Breaking changes

- `PointBoundary`, `PointCloud`, `PointSurface`, `import_surface`, and `suggest_spacing` path methods now **require a positional `unit`**. A bare `PointBoundary(filepath)` throws an `ArgumentError` with a migration hint (it would otherwise fall into the raw-points constructor and fail incomprehensibly).
- `TriangleOctree(filepath)` and `Octree(filepath)` are **removed** — octrees take the mesh you loaded through `import_mesh`, so boundary and octree always share one geometry object and one unit decision. The `(mesh)` constructors are unchanged.

## Why reinterpretation is safe

There is no `uconvert` anywhere in `src/` — octree construction, repel projection, and isinside all operate on raw stripped numbers and re-attach the cloud's own unit label. Changing the label at import leaves every numeric path untouched; it fixes what `suggest_spacing`, areas, and downstream physics *report*.

## Notes

- The unit semantics are reinterpretation by design: converting (46 m → 46000 mm) would change raw coordinates on one side of the label-blind octree↔cloud coupling and silently corrupt projection. Meshes.jl's `Scale`/`LengthUnit` transforms can't express this, hence the small manual vertex rebuild (same idiom as `sample_surface`).
- Docs: import sections rewritten mesh-first across guide/quickstart/index/README; API reference updated.
