### PR TITLE
fix(ci): publish stable docs and link them from the README

### DIFF
--- a/.github/workflows/documenter.yml
+++ b/.github/workflows/documenter.yml
@@ -6,10 +6,13 @@ on:
       - main
     tags: "*"
   pull_request:
+  workflow_dispatch:
 
+# All runs deploy to the same gh-pages branch, so serialize them: a main build
+# and a tag build have different refs and would otherwise race to push.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: ${{ startsWith(github.ref, 'refs/pull/') }}
+  group: docs
+  cancel-in-progress: false
 
 jobs:
   build:
@@ -19,6 +22,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
+        with:
+          # DocumenterVitepress runs `git tag` to decide whether the version being
+          # built earns the `stable` alias; a shallow checkout hides the tag list.
+          fetch-depth: 0
       - uses: julia-actions/setup-julia@v3
         with:
           version: "1.11"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -328,7 +328,7 @@ test/
 
 `.github/workflows/CI.yml` runs on Ubuntu with Julia 1.10, 1.11, and 1.12 across a 1- and 2-thread matrix. Tests trigger on pushes to main, tags, and PRs (excluding docs/license changes).
 
-Documentation builds via `documenter.yml` (and CI.yml's `docs` job, which also runs doctests) and deploys to GitHub Pages. Other workflows: `downgrade.yml` (lower-bound compat tests), `format.yml` (format check), `TagBot.yml`, `dependabot-automerge.yml`.
+Documentation builds via `documenter.yml`, which also runs doctests, and deploys to GitHub Pages. It runs on pushes to main, on tags, on PRs, and via `workflow_dispatch`; tag runs are what publish the `stable` docs, so they depend on TagBot pushing the tag over SSH with the `DOCUMENTER_KEY` deploy key (a `GITHUB_TOKEN`-created tag would not trigger any workflow). Other workflows: `downgrade.yml` (lower-bound compat tests), `format.yml` (format check), `TagBot.yml`, `dependabot-automerge.yml`.
 
 
 # Julia Best Practices

--- a/README.md
+++ b/README.md
@@ -8,7 +8,8 @@
 
 <p align="center">
   <a href="https://github.com/JuliaMeshless/WhatsThePoint.jl/actions/workflows/CI.yml?query=branch%3Amain"><img src="https://github.com/JuliaMeshless/WhatsThePoint.jl/actions/workflows/CI.yml/badge.svg?branch=main" alt="Build Status"></a>
-  <a href="https://JuliaMeshless.github.io/WhatsThePoint.jl/dev"><img src="https://img.shields.io/badge/docs-dev-blue.svg" alt="Documentation"></a>
+  <a href="https://JuliaMeshless.github.io/WhatsThePoint.jl/stable"><img src="https://img.shields.io/badge/docs-stable-blue.svg" alt="Stable Docs"></a>
+  <a href="https://JuliaMeshless.github.io/WhatsThePoint.jl/dev"><img src="https://img.shields.io/badge/docs-dev-blue.svg" alt="Dev Docs"></a>
   <a href="https://github.com/JuliaMeshless/WhatsThePoint.jl/blob/main/LICENSE"><img src="https://img.shields.io/badge/license-MIT-blue" alt="MIT License"></a>
   <a href="https://codecov.io/gh/JuliaMeshless/WhatsThePoint.jl"><img src="https://codecov.io/gh/JuliaMeshless/WhatsThePoint.jl/graph/badge.svg?token=S3BQ5FIULZ" alt="Coverage"></a>
 </p>
@@ -17,7 +18,7 @@
 
 Meshless methods — RBF-FD, generalized finite differences, SPH — need well-distributed point clouds with neighbor connectivity, but getting from a CAD surface to solver-ready points is tedious. WhatsThePoint.jl handles the complete pipeline: surface import, volume discretization, distribution optimization, and stencil connectivity, in a few lines of Julia. Part of the [JuliaMeshless](https://github.com/JuliaMeshless) organization.
 
-**[Full documentation](https://JuliaMeshless.github.io/WhatsThePoint.jl/dev)**
+**[Full documentation](https://JuliaMeshless.github.io/WhatsThePoint.jl/stable)**
 
 > [!NOTE]
 > WhatsThePoint.jl is under active development. The API may change before v1.0.


### PR DESCRIPTION
## Why

The README only advertised the dev docs, and a stable link would have 404'd: `gh-pages` contained only `dev/`, `previews/`, and a `versions.js` listing just `"dev"` — no `stable/`, no version directories — despite `v0.1.0`, `v0.2.0`, and `v0.3.0` all being tagged and registered in General.

## Root cause

The Documentation workflow has **never once run on a tag ref**. Not for lack of configuration: `documenter.yml` already had `tags: "*"`, and `TagBot.yml` already passed `ssh: ${{ secrets.DOCUMENTER_KEY }}`. The problem was that the `DOCUMENTER_KEY` secret and its deploy key did not exist on this repo.

With no SSH key, TagBot falls back to creating the release through the GitHub API using `GITHUB_TOKEN` — and GitHub deliberately does not fire workflow runs for events created by `GITHUB_TOKEN`. The v0.3.0 TagBot log shows exactly that (`Creating GitHub release v0.3.0 at d627a5c...`), with no tag-triggered run following.

Downstream, DocumenterVitepress's `determine_bases` only emits the `stable` / `vX.Y` aliases when the deploy subfolder is a version string, which happens only on a tag build. Every `main` push resolves to subfolder `dev`, so `bases == ["dev"]` and only `dev/` was ever written.

## What changed

A write-enabled `documenter` deploy key and the matching base64 `DOCUMENTER_KEY` secret are now registered on the repo (settings, not in this diff). That is the actual fix — TagBot will push future tags over SSH, which does trigger workflows.

Alongside it, in `documenter.yml`:

- `fetch-depth: 0` on checkout — DocumenterVitepress shells out to `git tag` to decide whether the version being built earns the `stable` alias, and a shallow checkout hides the tag list.
- `workflow_dispatch` — a manual re-run path (`gh workflow run documenter.yml --ref vX.Y.Z`) for any future tag whose build fails.
- Concurrency collapsed to a single `docs` group with `cancel-in-progress: false`. Every run pushes to `gh-pages`, and a main build and a tag build have different refs, so they could previously race. The tradeoff is losing PR-build cancellation; a clobbered deploy is the worse failure.

`README.md` gains the stable badge and the prose link now points at `/stable`. `CLAUDE.md` had claimed `CI.yml` has a `docs` job — it does not — so that line is corrected and now records the TagBot/SSH dependency.

`docs/make.jl` needs no change: `DocumenterVitepress.deploydocs` errors if handed a `versions` kwarg, and the auto-detected `deploy_decision` already does the right thing.

## Follow-up

`v0.3.0` is already tagged and will not retroactively build, so `stable/` stays empty — and the new badge 404s — until the next release. Cutting **v0.3.1** after this merges will populate it. For v0.3.1 with the default `keep = :breaking`, the bases built are exactly `["stable", "v0.3"]`; no patch or `v0` directory is expected.

---
<sub>🤖 Beep boop — Claude wrote this one; Kyle just pointed at RadialBasisFunctions.jl and said "like that".</sub>